### PR TITLE
Issue #2 - model and loader classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -21,6 +21,31 @@
             <version>1.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Maven Surefire Plugin for running tests with JUnit 5 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/SnotesExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/SnotesExtension.java
@@ -47,7 +47,7 @@ public class SnotesExtension extends CryptTextExtension {
     public SnotesExtension() {
         extInfo = AppExtensionInfo.fromExtensionJar(getClass(), extInfoLocation);
         if (extInfo == null) {
-            throw new RuntimeException("SnotesExtensino: can't parse extInfo.json!");
+            throw new RuntimeException("SnotesExtension: can't parse extInfo.json!");
         }
         this.snotesAction = new SnotesAction(this);
         this.snotesPanel = new SnotesPanel(this);

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/SnotesExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/SnotesExtension.java
@@ -1,18 +1,23 @@
-package ca.corbett.crypttext.extensions;
+package ca.corbett.crypttext.extensions.snotes;
 
 import ca.corbett.crypttext.AppConfig;
-import ca.corbett.crypttext.extensions.actions.SnotesAction;
-import ca.corbett.crypttext.extensions.ui.SnotesPanel;
+import ca.corbett.crypttext.Version;
+import ca.corbett.crypttext.extensions.CryptTextExtension;
+import ca.corbett.crypttext.extensions.ExtraComponentPosition;
+import ca.corbett.crypttext.extensions.snotes.actions.SnotesAction;
+import ca.corbett.crypttext.extensions.snotes.ui.SnotesPanel;
 import ca.corbett.crypttext.ui.actions.UIReloadAction;
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
+import ca.corbett.extras.properties.DirectoryProperty;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -32,6 +37,7 @@ public class SnotesExtension extends CryptTextExtension {
     private static final String extInfoLocation = "/ca/corbett/crypttext/extensions/snotes/extInfo.json";
     private static final String KEY_PROP = AppConfig.KEYSTROKE_PREFIX + "Snotes.snotesKey";
     private static final String PANEL_PROP = "Snotes.Snotes options.panelVisible";
+    private static final String DIR_PROP = "Snotes.Snotes options.snotesDirectory";
 
     private final AppExtensionInfo extInfo;
     private final SnotesAction snotesAction;
@@ -44,7 +50,7 @@ public class SnotesExtension extends CryptTextExtension {
             throw new RuntimeException("SnotesExtensino: can't parse extInfo.json!");
         }
         this.snotesAction = new SnotesAction(this);
-        this.snotesPanel = new SnotesPanel();
+        this.snotesPanel = new SnotesPanel(this);
         this.panelMenuItem = new JCheckBoxMenuItem(snotesAction);
     }
 
@@ -80,6 +86,14 @@ public class SnotesExtension extends CryptTextExtension {
         list.add(new BooleanProperty(PANEL_PROP,
                                      "Show Snotes panel",
                                      true));
+
+        // The directory where are notes are stored:
+        // (note we offer a lousy default here, but the user will change it right away, so it's okay)
+        list.add(new DirectoryProperty(DIR_PROP,
+                                       "Data directory:",
+                                       true,
+                                       Version.SETTINGS_DIR)
+                         .setHelpText("The directory where your notes are stored."));
 
         return list;
     }
@@ -127,6 +141,18 @@ public class SnotesExtension extends CryptTextExtension {
         AppConfig.getInstance().save(); // Trigger an immediate save so the value is persisted
         panelMenuItem.setState(isVisibleNow);
         UIReloadAction.getInstance().actionPerformed(null); // Trigger immediate UI reload
+    }
+
+    /**
+     * Returns our currently configured data directory, or null if one isn't set.
+     */
+    public File getConfiguredDataDirectory() {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(DIR_PROP);
+        if (!(prop instanceof DirectoryProperty dirProp)) {
+            log.severe("SnotesExtension: unable to find data directory property!");
+            return null;
+        }
+        return dirProp.getDirectory();
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/actions/SnotesAction.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/actions/SnotesAction.java
@@ -1,6 +1,6 @@
-package ca.corbett.crypttext.extensions.actions;
+package ca.corbett.crypttext.extensions.snotes.actions;
 
-import ca.corbett.crypttext.extensions.SnotesExtension;
+import ca.corbett.crypttext.extensions.snotes.SnotesExtension;
 import ca.corbett.extras.EnhancedAction;
 
 import java.awt.event.ActionEvent;

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
@@ -1,0 +1,113 @@
+package ca.corbett.crypttext.extensions.snotes.io;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.crypttext.extensions.snotes.model.YMDDate;
+import ca.corbett.extras.io.FileSystemUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * A utility class for loading and saving Note objects.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class SnotesIO {
+
+    private static final Logger log = Logger.getLogger(SnotesIO.class.getName());
+
+    /**
+     * Attempts to load a Note from the given file, and will throw an IOException
+     * if something goes wrong.
+     *
+     * @param file The file to load the Note from. Must be a readable file that exists on disk.
+     * @return A Note object representing the content of the given file.
+     * @throws IOException If anything at all goes wrong with the load.
+     */
+    public static Note loadNote(File file) throws IOException {
+        if (file == null || !file.exists() || !file.isFile() || !file.canRead()) {
+            throw new IOException("File does not exist or is not a readable file.");
+        }
+        Note note = new Note();
+        note.setSourceFile(file);
+        List<String> lines = FileSystemUtil.readFileLines(file);
+        if (lines.isEmpty()) {
+            throw new IOException("File is empty.");
+        }
+
+        // The first line is the tag line:
+        String tagLine = lines.get(0);
+        if (!tagLine.contains("#")) {
+            // This used to be considered a fatal error, but eh...
+            // let's just log it as a warning. It's fine.
+            log.warning("Note " + file.getAbsolutePath() + " has no tags.");
+        }
+
+        else {
+            // Split the tags and load each one:
+            String[] tags = tagLine.replaceAll("#", "").split(" ");
+            int tagIndex = 0;
+            if (YMDDate.isValidYMD(tags[0])) { // If there's a date tag, it'll be the first one
+                tagIndex = 1;
+                note.setDate(new YMDDate(tags[0]));
+            }
+            for (int i = tagIndex; i < tags.length; i++) {
+                if (YMDDate.isValidYMD(tags[i])) {
+                    // This makes no sense and is certainly an error:
+                    throw new IOException("Multiple date tags found in Note " + file.getAbsolutePath());
+                }
+                note.tag(tags[i]);
+            }
+        }
+
+        if (lines.size() < 2) {
+            // No content, but that's fine - we'll just return an empty Note.
+            return note;
+        }
+
+        int lineIndex = 1;
+        if (lines.get(1).trim().isEmpty()) {
+            lineIndex++; // skip first blank line.
+        }
+
+        for (int i = lineIndex; i < lines.size(); i++) {
+            note.append(lines.get(i));
+            note.newline();
+        }
+
+        note.markClean(); // ignore all those changes we just made to the model object - it's in sync with disk.
+        return note;
+    }
+
+    /**
+     * Attempts to save the given Note to disk, and will throw an IOException if something goes wrong.
+     *
+     * @param note The Note to save. Must not be null, and must have a non-null source file.
+     * @throws IOException If anything at all goes wrong with the save.
+     */
+    public static void saveNote(Note note) throws IOException {
+        if (note == null) {
+            throw new IllegalArgumentException("Cannot save a null Note.");
+        }
+        if (note.getSourceFile() == null) {
+            throw new IllegalArgumentException("Cannot save a Note with no source file.");
+        }
+
+        List<String> lines = new ArrayList<>();
+        lines.add(note.getPersistenceTagLine());
+        lines.add(""); // blank line between tags and text is conventional.
+
+        // We'll preserve whatever line separators are in the Note's text.
+        // This might be none at all if line-wrapping is enabled in the editor, but that's fine.
+        lines.add(note.getText());
+
+        // Write it:
+        FileSystemUtil.writeLinesToFile(lines, note.getSourceFile());
+
+        // If we make it this far, the Note is clean:
+        note.markClean();
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
@@ -65,6 +65,7 @@ public class SnotesIO {
 
         if (lines.size() < 2) {
             // No content, but that's fine - we'll just return an empty Note.
+            note.markClean();
             return note;
         }
 

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
@@ -48,18 +48,23 @@ public class SnotesIO {
 
         else {
             // Split the tags and load each one:
-            String[] tags = tagLine.replaceAll("#", "").split(" ");
-            int tagIndex = 0;
-            if (YMDDate.isValidYMD(tags[0])) { // If there's a date tag, it'll be the first one
-                tagIndex = 1;
-                note.setDate(new YMDDate(tags[0]));
-            }
-            for (int i = tagIndex; i < tags.length; i++) {
-                if (YMDDate.isValidYMD(tags[i])) {
-                    // This makes no sense and is certainly an error:
-                    throw new IOException("Multiple date tags found in Note " + file.getAbsolutePath());
+            String cleanedTagLine = tagLine.replaceAll("#", "").trim();
+            if (!cleanedTagLine.isEmpty()) {
+                String[] tags = cleanedTagLine.split("\\s+");
+                int tagIndex = 0;
+                if (tags.length > 0 && YMDDate.isValidYMD(tags[0])) { // If there's a date tag, it'll be the first one
+                    tagIndex = 1;
+                    note.setDate(new YMDDate(tags[0]));
                 }
-                note.tag(tags[i]);
+                for (int i = tagIndex; i < tags.length; i++) {
+                    if (YMDDate.isValidYMD(tags[i])) {
+                        // This makes no sense and is certainly an error:
+                        throw new IOException("Multiple date tags found in Note " + file.getAbsolutePath());
+                    }
+                    note.tag(tags[i]);
+                }
+            } else {
+                log.warning("Note " + file.getAbsolutePath() + " has no parsable tags.");
             }
         }
 

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
@@ -1,0 +1,58 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+/**
+ * DateTag is a special case of Tag, where the Tag value is always represented
+ * in YMDDate format. If you supply some value that does not conform to the
+ * yyyy-MM-dd format, then a default value of today's date will be used.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 1.0
+ */
+public final class DateTag extends Tag {
+
+    final YMDDate dateTag;
+
+    /**
+     * You can create a DateTag by providing a String in yyyy-mm-dd format.
+     * A String in any other format will be ignored, and today's date will
+     * be used instead.
+     *
+     * @param val A yyyy-MM-dd format string. If invalid, today's date is used.
+     */
+    public DateTag(String val) {
+        this(new YMDDate(val));
+    }
+
+    /**
+     * You can create a DateTag by providing a YMDDate object. If the
+     * object is null, it will be ignored and today's date will be used.
+     */
+    public DateTag(YMDDate date) {
+        super(date == null ? new YMDDate().toString() : date.toString());
+        dateTag = new YMDDate(this.tag);
+    }
+
+    /**
+     * You can create a DateTag based on some other DateTag.
+     */
+    public DateTag(DateTag other) {
+        this(other == null ? new YMDDate() : other.getDate());
+    }
+
+    /**
+     * Returns a copy of the YMDDate object that this tag represents.
+     */
+    public YMDDate getDate() {
+        return dateTag;
+    }
+
+    @Override
+    public int compareTo(Tag other) {
+        if (other instanceof DateTag otherDateTag) {
+            return dateTag.compareTo(otherDateTag.dateTag);
+        }
+        else {
+            return super.compareTo(other);
+        }
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
@@ -43,7 +43,7 @@ public final class DateTag extends Tag {
      * Returns a copy of the YMDDate object that this tag represents.
      */
     public YMDDate getDate() {
-        return dateTag;
+        return new YMDDate(dateTag.toString());
     }
 
     @Override

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
@@ -91,7 +91,7 @@ public final class Note {
      * Does not automatically add a newline - use newline() or embed
      * newline characters in newText.
      *
-     * @param newText The text to append to this Nte.
+     * @param newText The text to append to this Note.
      */
     public void append(String newText) {
         text += newText;

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
@@ -1,0 +1,254 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Represents a combination of some text and a list of tags that categorize that text.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 1.0
+ */
+public final class Note {
+
+    private final TagList tagList;
+    private String text;
+    private File sourceFile;
+    private boolean isDirty;
+
+    /**
+     * Creates an empty, untagged Note.
+     */
+    public Note() {
+        tagList = new TagList();
+        text = "";
+        sourceFile = null;
+        isDirty = false;
+    }
+
+    /**
+     * The persistence file for this Note, or null if this Note has
+     * not yet been saved to disk.
+     *
+     * @param src The File from which this Note was loaded, if applicable.
+     */
+    public void setSourceFile(File src) {
+        sourceFile = src;
+        isDirty = true;
+    }
+
+    /**
+     * The persistence file for this Note, or null if this Note has
+     * not yet been saved to disk.
+     *
+     * @return The File from which this Note was loaded, or null if not applicable.
+     */
+    public File getSourceFile() {
+        return sourceFile;
+    }
+
+    /**
+     * Indicates whether this Note has a date tag associated with it or not.
+     *
+     * @return True if a date tag has been assigned to this Note.
+     */
+    public boolean hasDate() {
+        return tagList.hasDate();
+    }
+
+    /**
+     * Returns the YMDDate associated with this Note, if any.
+     *
+     * @return A YMDDate object, or null if this Note is not dated.
+     */
+    public YMDDate getDate() {
+        return tagList.hasDate() ? tagList.getDateTag().getDate() : null;
+    }
+
+    /**
+     * Sets the YMDDate for this Note, and replaces any previous date that was set.
+     * Passing null will convert this Note to an undated one.
+     *
+     * @param date The new YMDDate for this Note, or null for no date.
+     */
+    public void setDate(YMDDate date) {
+        tagList.setDate(date);
+        isDirty = true;
+    }
+
+    /**
+     * Replaces any existing text for this Note with the given text.
+     *
+     * @param newText The new text value for this Note.
+     */
+    public void setText(String newText) {
+        text = newText == null ? "" : newText;
+        isDirty = true;
+    }
+
+    /**
+     * Appends the given text to the existing text of this Note.
+     * Does not automatically add a newline - use newline() or embed
+     * newline characters in newText.
+     *
+     * @param newText The text to append to this Nte.
+     */
+    public void append(String newText) {
+        text += newText;
+        isDirty = true;
+    }
+
+    /**
+     * Appends a System-specific newline character to this Note.
+     */
+    public void newline() {
+        text += System.lineSeparator();
+        isDirty = true;
+    }
+
+    /**
+     * Indicates whether any text has been set for this Note.
+     *
+     * @return True if any text exists here.
+     */
+    public boolean hasText() {
+        return text != null && !text.isBlank();
+    }
+
+    /**
+     * Returns the current text value of this Note. This does NOT include the
+     * tag line at the beginning - only the actual text content is returned.
+     * You may want getFullContent() instead.
+     *
+     * @return The text of this Note.
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Returns the human-presentable tag line for this Note.
+     *
+     * @return A human-readable tag line for this Note.
+     */
+    public String getHumanTagLine() {
+        return tagList.toString();
+    }
+
+    /**
+     * Returns the persistable tag line for this Note.
+     *
+     * @return A machine-readable tag line for this Note.
+     */
+    public String getPersistenceTagLine() {
+        return tagList.getPersistenceString();
+    }
+
+    /**
+     * Returns the full content of this Note - that is, the human-readable tag line, followed by a blank
+     * line, followed by the text content of this Note. This call is equivalent to
+     * the following:
+     * <p>
+     * getTagLine() + System.lineSeparator() + getText()
+     * </p>
+     *
+     * @return The full text content of this Note as described above.
+     */
+    public String getFullContent() {
+        return getHumanTagLine() + System.lineSeparator() + getText();
+    }
+
+    /**
+     * Adds the specified Tag to this Note, if not already present. Duplicates are ignored.
+     * If the given Tag is a DateTag, this is equivalent to calling setDate()
+     *
+     * @param tag The Tag to add.
+     */
+    public void tag(Tag tag) {
+        tagList.addTag(tag);
+        isDirty = true;
+    }
+
+    /**
+     * Adds the specified tag value to this Note, if not already present. Duplicate tags are ignored.
+     *
+     * @param tag The tag value to add.
+     */
+    public void tag(String tag) {
+        tagList.addTag(tag);
+        isDirty = true;
+    }
+
+    /**
+     * Removes the given tag from this Note, if present.
+     *
+     * @param tag The tag to remove.
+     */
+    public void untag(String tag) {
+        if (tagList.removeTag(tag)) {
+            isDirty = true;
+        }
+    }
+
+    /**
+     * Removes the given tag from this Note, if present.
+     *
+     * @param tag The tag to remove.
+     */
+    public void untag(Tag tag) {
+        if (tagList.removeTag(tag)) {
+            isDirty = true;
+        }
+    }
+
+    /**
+     * Indicates whether or not the given tag value exists for this Note.
+     *
+     * @param tag The tag value to look for.
+     * @return True if the given tag value exists here.
+     */
+    public boolean hasTag(String tag) {
+        return tagList.hasTag(tag);
+    }
+
+    /**
+     * Indicates whether or not the given tag exists for this Note.
+     *
+     * @param tag The Tag to look for.
+     * @return True if the given Tag exists here.
+     */
+    public boolean hasTag(Tag tag) {
+        return tagList.hasTag(tag);
+    }
+
+    /**
+     * Returns a copy of the list of tags for this Note. If you want to make
+     * modifications, use the tag() and untag() methods.
+     *
+     * @return A copy of the list of tags for this Note.
+     */
+    public List<Tag> getTags() {
+        return tagList.getTags();
+    }
+
+    /**
+     * Returns a list of all non-date tags for this Note.
+     */
+    public List<Tag> getNonDateTags() {
+        return tagList.getNonDateTags();
+    }
+
+    /**
+     * Returns true if this Note contains changes that have not been persisted to disk.
+     */
+    public boolean isDirty() {
+        return isDirty;
+    }
+
+    /**
+     * Marks this Note as clean, indicating that all changes have been persisted to disk.
+     */
+    public void markClean() {
+        isDirty = false;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Tag.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Tag.java
@@ -1,0 +1,106 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import java.util.Objects;
+
+/**
+ * A Tag is some string label that is attached to a Note, in order to categorize it.
+ * Tags are primarily used for searching and filtering Notes.
+ * <p>
+ * Tags cannot contain spaces, forward slashes, or backslashes - these characters
+ * are replaced with underscores. Tags are always converted to all lower case.
+ * Leading and trailing spaces are trimmed. Tags always start with the "#" character,
+ * and cannot contain that character.
+ * </p>
+ * <p>
+ * Each Note can have zero or more Tags.
+ * </p>
+ * <p>
+ * If a tag value fits the yyyy-MM-dd format, it is considered a "date" tag.
+ * Each Note can have at most one date tag.
+ * </p>
+ * <p>
+ * Tags are immutable.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 1.0
+ */
+public class Tag implements Comparable<Tag> {
+
+    protected final String tag;
+
+    /**
+     * Instantiate by providing any string value. The given value will be validated and
+     * possibly adjusted to substitute invalid characters.
+     *
+     * @param tag The String value for this Tag.
+     */
+    public Tag(String tag) {
+        this.tag = validateTag(tag);
+    }
+
+    /**
+     * Returns the raw Tag value as a String, NOT including the leading hash sign.
+     * See toString() for the Snotes-friendly format of this Tag.
+     *
+     * @return The Tag value.
+     */
+    public String getTag() {
+        return tag;
+    }
+
+    /**
+     * Returns the Tag value in a Snotes-friendly format. This is a hash sign followed
+     * by the Tag string value.
+     *
+     * @return The Tag value in a Snotes-ready format (eg. "#tagvalue")
+     */
+    @Override
+    public String toString() {
+        return "#" + tag;
+    }
+
+    /**
+     * Performs validation on the input tag value and returns a sanitized version of it.
+     * "Sanitized" here means that the tag is unconditionally lower-cased, trimmed, and
+     * has spaces, foreward/backslashes, and hash characters replaced with underscores.
+     * If the input is null or blank, an IllegalArgumentException is thrown.
+     * <p>
+     * <b>Note</b>: the resulting tag value may not match what was passed in!
+     * </p>
+     * <pre>
+     *     validateTag("Hello/World Tag ") -> "hello_world_tag"
+     * </pre>
+     *
+     * @param s The candidate tag value.
+     * @return The sanitized tag value.
+     * @throws IllegalArgumentException if the input is null or blank.
+     */
+    protected String validateTag(String s) {
+        if (s == null || s.isBlank()) {
+            throw new IllegalArgumentException("Tag value cannot be null or blank.");
+        }
+        String validatedTag = s.toLowerCase().trim(); // Cannot have leading/trailing spaces
+        return validatedTag.replaceAll(" ", "_") // Cannot contain spaces
+                           .replaceAll("/", "_") // Cannot contain forward slashes
+                           .replaceAll("\\\\", "_") // Cannot contain backslashes
+                           .replaceAll("#", "_"); // Cannot contain hash signs
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) { return false; }
+        Tag tag1 = (Tag)o;
+        return Objects.equals(tag, tag1.tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tag);
+    }
+
+    @Override
+    public int compareTo(Tag other) {
+        return this.tag.compareTo(other.tag);
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/TagList.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/TagList.java
@@ -1,0 +1,287 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+
+/**
+ * Represents a list of Tags that can be applied to a Note.
+ * There's some logic to the content of a Note's tag list. Namely:
+ * <ul>
+ * <li>If a DateTag is in the list, there must be at most one.</li>
+ * <li>Tags are kept sorted such that the DateTag (if present) shows up first always.</li>
+ * <li>Subsequent Tags are listed in alphabetical order.</li>
+ * <li>Attempts to add duplicate tags are ignored (tags are unique within a TagList).</li>
+ * <li>Tag values are subject to the validation/sanitization rules defined in Tag and DateTag.</li>
+ * </ul>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 1.0
+ */
+public final class TagList {
+
+    private static final Logger log = Logger.getLogger(TagList.class.getName());
+
+    private DateTag dateTag;
+    private final SortedSet<Tag> tags;
+
+    /**
+     * Creates an empty, undated tag list.
+     */
+    public TagList() {
+        dateTag = null;
+        tags = new TreeSet<>();
+    }
+
+    /**
+     * Creates a TagList with the given date. If the given date is null,
+     * today's date will be used. To create an undated TagList,
+     * use the no-args constructor instead.
+     *
+     * @param date The date for this tag list.
+     */
+    public TagList(YMDDate date) {
+        if (date == null) {
+            date = new YMDDate();
+        }
+        dateTag = new DateTag(date);
+        tags = new TreeSet<>();
+    }
+
+    /**
+     * Sets the date using the given string in yyyy-MM-dd format.
+     * If badly formatted, the date will be set to today's date.
+     * If null, the date for this tag list will be removed.
+     * Any previous date for this TagList will be replaced -
+     * a TagList can only have one DateTag at a time!
+     *
+     * @param date A String hopefully in yyyy-MM-dd format.
+     */
+    public void setDate(String date) {
+        dateTag = (date == null) ? null : new DateTag(date);
+    }
+
+    /**
+     * Sets the date using the given YMDDate object.
+     * If invalid, today's date will be used.
+     * If null, the date for this tag list will be removed.
+     * Any previous date for this TagList will be replaced -
+     * a TagList can only have one DateTag at a time!
+     *
+     * @param date The date for this tag list, or null to clear the date.
+     */
+    public void setDate(YMDDate date) {
+        dateTag = (date == null) ? null : new DateTag(date);
+    }
+
+    /**
+     * Sets the date for this tag list using the given DateTag.
+     * A null value is valid here, and means "remove the date from this TagList".
+     * Any previous date for this TagList will be replaced -
+     * a TagList can only have one DateTag at a time!
+     *
+     * @param newTag The date for this tag list, or null to clear the date.
+     */
+    public void setDateTag(DateTag newTag) {
+        dateTag = (newTag == null) ? null : new DateTag(newTag);
+    }
+
+    /**
+     * Returns the DateTag for this tag list, or null if there isn't one.
+     */
+    public DateTag getDateTag() {
+        return dateTag;
+    }
+
+    /**
+     * Indicates whether this TagList has a DateTag or not.
+     */
+    public boolean hasDate() {
+        return dateTag != null;
+    }
+
+    /**
+     * Adds the given tag to this list. If the input string is in yyyy-MM-dd format,
+     * then this will set the DateTag for this list instance. Otherwise, the
+     * input string is treated as a normal Tag.
+     */
+    public void addTag(String tagString) {
+        if (YMDDate.isValidYMD(tagString)) {
+            setDateTag(new DateTag(tagString));
+            return;
+        }
+        addTag(new Tag(tagString));
+    }
+
+    /**
+     * Adds the given tag to this list.
+     * If the given Tag is a DateTag, then this is equivalent
+     * to calling setDateTag(tag);
+     */
+    public void addTag(Tag tag) {
+        if (tag instanceof DateTag) {
+            setDateTag((DateTag)tag);
+            return;
+        }
+        tags.add(tag);
+    }
+
+    /**
+     * Removes the given tag from this list, if it was present.
+     *
+     * @return True if the tag was found and removed, false if the tag was not found in this list.
+     */
+    public boolean removeTag(String tagString) {
+        return removeTag(YMDDate.isValidYMD(tagString) ? new DateTag(tagString) : new Tag(tagString));
+    }
+
+    /**
+     * Removes the given tag from this list, if it was present.
+     * If the given tag is a DateTag that matches the DateTag for
+     * this tag list, then this is equivalent to setDateTag(null).
+     *
+     * @param tag The tag to remove from this list.
+     * @return True if the tag was found and removed, false if the tag was not found in this list.
+     */
+    public boolean removeTag(Tag tag) {
+        if (tag instanceof DateTag dateTagToRemove) {
+            if (dateTagToRemove.equals(dateTag)) {
+                dateTag = null;
+                return false;
+            }
+            else {
+                log.warning("Attempted to remove a DateTag that is not present in this TagList. No action taken.");
+            }
+        }
+        return tags.remove(tag);
+    }
+
+    /**
+     * Returns the count of tags (including optional DateTag) in this list.
+     *
+     * @return How many tags are present.
+     */
+    public int size() {
+        int size = (dateTag != null) ? 1 : 0;
+        return size + tags.size();
+    }
+
+    /**
+     * Removes all tags from this list, including the DateTag.
+     */
+    public void clear() {
+        dateTag = null;
+        tags.clear();
+    }
+
+    /**
+     * Reports whether the specified tag is contained in this tag list.
+     * This is shorthand for hasTag(new Tag(tag));
+     *
+     * @param tag The String value to search.
+     * @return True if the given tag is present in this tag list.
+     */
+    public boolean hasTag(String tag) {
+        // normalize the input so we're comparing apples to apples, and also handle DateTags.
+        return hasTag(YMDDate.isValidYMD(tag) ? new DateTag(tag) : new Tag(tag));
+    }
+
+    /**
+     * Reports whether the specified tag is contained in this tag list.
+     * If the given tag is a DateTag, then this checks if it matches the DateTag for this TagList.
+     * Otherwise, it checks if the given tag is present in the set of non-date tags for this TagList.
+     *
+     * @param tag The value to search.
+     * @return True if the given tag is present in this tag list.
+     */
+    public boolean hasTag(Tag tag) {
+        if (tag instanceof DateTag theDateTag) {
+            return theDateTag.equals(dateTag);
+        }
+        return tags.contains(tag);
+    }
+
+    /**
+     * Returns a sorted list of tags contained in this list.
+     * If a DateTag is present, it is always returned first.
+     * All other tags are returned in alphabetical order after the DateTag.
+     * To exclude the DateTag, use getNonDateTags() instead.
+     *
+     * @return A list of all tags in this list.
+     */
+    public List<Tag> getTags() {
+        List<Tag> result = new ArrayList<>();
+        if (dateTag != null) {
+            result.add(dateTag);
+        }
+        result.addAll(tags); // tags is a SortedSet, so it's already sorted.
+        return result;
+    }
+
+    /**
+     * Returns a sorted list of all non-date tags contained in this list.
+     *
+     * @return A list of all non-date tags in this list.
+     */
+    public List<Tag> getNonDateTags() {
+        return new ArrayList<>(tags); // tags is a SortedSet, so it's already sorted.
+    }
+
+    /**
+     * Returns a machine-readable String representation of this TagList, suitable for persistence to disk.
+     * If a date tag is present, it is presented first, in yyyy-MM-dd format.
+     * All other tags follow, in alphabetical order, separated by spaces.
+     *
+     * @return A machine-readable String representation of this TagList, suitable for persistence to disk.
+     */
+    public String getPersistenceString() {
+        StringBuilder sb = new StringBuilder();
+        if (dateTag != null) {
+            sb.append(dateTag);
+            sb.append(" ");
+        }
+        for (Tag tag : tags) {
+            sb.append(tag.toString()); // # plus tag contents
+            sb.append(" ");
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Returns a human-presentable String representation of this TagList.
+     * If a date tag is present, it is presented first, with the day name in parentheses.
+     * All other tags follow, in alphabetical order. For example, given a date
+     * tag of 1997-04-21 and two normal tags "tag1" and "tag2", the output would be:
+     * <pre>
+     *     #1997-04-21 (Monday) #tag1 #tag2
+     * </pre>
+     *
+     * @return A human-presentable String representation of this TagList.
+     */
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        if (hasDate()) {
+            builder.append("#");
+            builder.append(dateTag.getDate().toString());
+            builder.append(" (");
+            builder.append(dateTag.getDate().getDayName());
+            builder.append(")");
+
+            if (!tags.isEmpty()) {
+                builder.append(" ");
+            }
+        }
+        for (Tag tag : tags) {
+            if (tag instanceof DateTag) {
+                continue; // skip the date already output above
+            }
+            builder.append("#");
+            builder.append(tag.getTag());
+            builder.append(" ");
+        }
+        return builder.toString().trim() + System.lineSeparator();
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/TagList.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/TagList.java
@@ -149,7 +149,7 @@ public final class TagList {
         if (tag instanceof DateTag dateTagToRemove) {
             if (dateTagToRemove.equals(dateTag)) {
                 dateTag = null;
-                return false;
+                return true;
             }
             else {
                 log.warning("Attempted to remove a DateTag that is not present in this TagList. No action taken.");

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
@@ -1,0 +1,139 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.time.format.TextStyle;
+import java.util.logging.Logger;
+
+/**
+ * A simple wrapper around dates in a hard-coded yyyy-MM-dd format.
+ * All date values are represented in this format.
+ * <p>
+ * YMDDate instances are immutable, and always contain a valid date,
+ * defaulting to today's date if given bad input.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 1.0
+ */
+public class YMDDate implements Comparable<YMDDate> {
+    /**
+     * Note: we have to use "uuuu" and ResolverStyle.STRICT here, because the default is a little too loose.
+     * Without STRICT, the parser will accept dates that are technically invalid. Actual example: "2024-02-30".
+     * Weirdly, using "yyyy" with ResolverStyle.STRICT rejects valid dates. Actual example: "2024-01-01".
+     * Only the combination of both "uuuu" and STRICT seems to resolve dates correctly.
+     */
+    protected static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd")
+                                                                          .withResolverStyle(ResolverStyle.STRICT);
+    private static final Logger log = Logger.getLogger(YMDDate.class.getName());
+    protected LocalDate date;
+
+    /**
+     * Constructs a YMDDate representing today's date.
+     */
+    public YMDDate() {
+        date = LocalDate.now();
+    }
+
+    /**
+     * Attempts to construct a YMDDate from the given String in yyyy-MM-dd format.
+     * If the String is badly formatted, a warning is logged, and today's date will be used instead.
+     */
+    public YMDDate(String ymdString) {
+        try {
+            date = ymdString == null ? LocalDate.now() : LocalDate.parse(ymdString, FORMATTER);
+        }
+        catch (Exception e) {
+            log.warning("Invalid date string '" + ymdString + "': " + e.getMessage() + ". Using today's date instead.");
+            date = LocalDate.now();
+        }
+    }
+
+    /**
+     * For unit testing purposes, to make it easier to create test objects.
+     */
+    protected YMDDate(LocalDate date) {
+        this.date = date;
+    }
+
+    /**
+     * Returns the day prior to this date.
+     */
+    public YMDDate getYesterday() {
+        LocalDate yesterday = date.minusDays(1);
+        return new YMDDate(yesterday.format(FORMATTER));
+    }
+
+    /**
+     * Returns the day after this date.
+     */
+    public YMDDate getTomorrow() {
+        LocalDate tomorrow = date.plusDays(1);
+        return new YMDDate(tomorrow.format(FORMATTER));
+    }
+
+    /**
+     * Returns the human-readable name of the day of the week for this date.
+     * <p>
+     * This value is NOT used for tagging purposes, but can be used when displaying
+     * a dated Note to the user.
+     * </p>
+     */
+    public String getDayName() {
+        return date.getDayOfWeek().getDisplayName(TextStyle.FULL, java.util.Locale.getDefault());
+    }
+
+    /**
+     * Returns the year in string format (four digits always).
+     */
+    public String getYearStr() {
+        return String.format("%04d", date.getYear());
+    }
+
+    /**
+     * Returns the month in string format (two digits always).
+     */
+    public String getMonthStr() {
+        return String.format("%02d", date.getMonthValue());
+    }
+
+    /**
+     * Returns the day of month in string format (two digits always).
+     */
+    public String getDayStr() {
+        return String.format("%02d", date.getDayOfMonth());
+    }
+
+    /**
+     * Returns a yyyy-MM-dd formatted String representation of this date.
+     */
+    @Override
+    public String toString() {
+        return date.format(FORMATTER);
+    }
+
+    /**
+     * Reports whether the given String conforms to yyyy-MM-dd format.
+     */
+    public static boolean isValidYMD(String candidate) {
+        try {
+            LocalDate.parse(candidate, FORMATTER);
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Compares this YMDDate to another.
+     */
+    @Override
+    public int compareTo(YMDDate o) {
+        if (o == null) {
+            return 1;
+        }
+        return this.date.compareTo(o.date);
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
@@ -27,7 +27,7 @@ public class YMDDate implements Comparable<YMDDate> {
     protected static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd")
                                                                           .withResolverStyle(ResolverStyle.STRICT);
     private static final Logger log = Logger.getLogger(YMDDate.class.getName());
-    protected LocalDate date;
+    protected final LocalDate date;
 
     /**
      * Constructs a YMDDate representing today's date.

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
@@ -41,6 +41,7 @@ public class YMDDate implements Comparable<YMDDate> {
      * If the String is badly formatted, a warning is logged, and today's date will be used instead.
      */
     public YMDDate(String ymdString) {
+        LocalDate date;
         try {
             date = ymdString == null ? LocalDate.now() : LocalDate.parse(ymdString, FORMATTER);
         }
@@ -48,6 +49,7 @@ public class YMDDate implements Comparable<YMDDate> {
             log.warning("Invalid date string '" + ymdString + "': " + e.getMessage() + ". Using today's date instead.");
             date = LocalDate.now();
         }
+        this.date = date;
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/threads/SnotesLoaderThread.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/threads/SnotesLoaderThread.java
@@ -72,7 +72,7 @@ public class SnotesLoaderThread extends SimpleProgressWorker {
      * </p>
      */
     public List<Note> getSearchResults() {
-        return searchResults;
+        return new ArrayList<>(searchResults); // return a copy in case we are re-run and clear our list
     }
 
     @Override

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/threads/SnotesLoaderThread.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/threads/SnotesLoaderThread.java
@@ -1,0 +1,155 @@
+package ca.corbett.crypttext.extensions.snotes.threads;
+
+import ca.corbett.crypttext.extensions.snotes.io.SnotesIO;
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.extras.progress.SimpleProgressWorker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A worker thread that will scan a given directory, and return an in-memory
+ * cache of all Notes and Tags found there. As this is a potentially heavy
+ * IO operation, it gets its own worker thread, and should never be executed
+ * on the Swing EDT.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class SnotesLoaderThread extends SimpleProgressWorker {
+
+    private static final Logger log = Logger.getLogger(SnotesLoaderThread.class.getName());
+
+    private final List<Note> searchResults;
+    private final List<String> directoriesToSkip;
+    private final File directory;
+    private boolean wasCanceled;
+
+    /**
+     * Creates a SnotesLoaderThread that will scan the given directory for Note text files.
+     * You can optionally invoke addDirectoryToSkip() on this thread to specify named
+     * directories to be skipped during the loading process.
+     *
+     * @param directory The directory to scan for Note text files. Must be a readable directory that exists on disk.
+     */
+    public SnotesLoaderThread(File directory) {
+        this.directory = directory;
+        this.directoriesToSkip = new ArrayList<>();
+        this.searchResults = new ArrayList<>();
+    }
+
+    /**
+     * You can optionally specify named directories to be skipped during the loading process.
+     * The given dirName can either be a fully qualified path, or just the name of the directory.
+     * For example, to skip all Mercurial directories: addDirectoryToSkip(".hg")
+     *
+     * @param dirName The name of the directory to skip. Can be a fully qualified path, or just a directory name.
+     * @return This SnotesLoaderThread, for chaining.
+     */
+    public SnotesLoaderThread addDirectoryToSkip(String dirName) {
+        directoriesToSkip.add(dirName);
+        return this;
+    }
+
+    /**
+     * Returns true if the search was canceled partway through by the user.
+     * The searchResults will be incomplete in this case.
+     */
+    public boolean wasCanceled() {
+        return wasCanceled;
+    }
+
+    /**
+     * Returns the results of the search. May be empty, but will never be null.
+     * <B>NOTE:</B> if the search was canceled by the user, this list will be incomplete.
+     * <p>
+     * Results are returned in whatever order we found them on the filesystem.
+     * It's up to the caller to make sense of the resulting list.
+     * </p>
+     */
+    public List<Note> getSearchResults() {
+        return searchResults;
+    }
+
+    @Override
+    public void run() {
+        searchResults.clear();
+        wasCanceled = false;
+
+        // Sanity check our settings:
+        if (directory == null || !directory.exists() || !directory.isDirectory()) {
+            log.severe("Skipping invalid directory specified for SnotesLoaderThread: " + directory);
+            return;
+        }
+
+        // Force the progress bar to appear while we enumerate the files, since this can be a heavy operation:
+        fireProgressBegins(1); // 1 is just a dummy value until we know how many files there are
+        try {
+            List<File> fileList = FileSystemUtil.findFiles(directory, true, "txt");
+
+            // Now we can set the actual progress bounds:
+            fireProgressBegins(fileList.size());
+
+            for (int i = 0; i < fileList.size(); i++) {
+                File file = fileList.get(i);
+
+                // Check if this file is in a directory we want to skip:
+                if (shouldSkipFile(file)) {
+                    continue;
+                }
+
+                try {
+                    searchResults.add(SnotesIO.loadNote(file));
+                }
+                catch (IOException ioe) {
+                    // Log the error and keep going. One bad file shouldn't stop the whole operation.
+                    log.log(Level.SEVERE, "Problem loading Note: " + file.getAbsolutePath(), ioe);
+                }
+
+                // Update progress and check for user cancellation:
+                if (!fireProgressUpdate(i, file.getAbsolutePath())) {
+                    wasCanceled = true;
+                    break;
+                }
+            }
+        }
+        finally {
+            // Ensure the progress bar is closed, one way or another:
+            if (wasCanceled) {
+                log.warning("SnotesLoaderThread was canceled by the user.");
+                fireProgressCanceled();
+            }
+            else {
+                fireProgressComplete();
+            }
+        }
+    }
+
+    /**
+     * Invoked internally to determine if the given file is in any of our "skip" directories.
+     */
+    private boolean shouldSkipFile(File file) {
+        for (String dirToSkip : directoriesToSkip) {
+            // This is a bit of a hack that only works on Linux, but the contract
+            // for addDirectoryToSkip() allows the caller to specify a fully qualified path.
+            // So, if this looks like an absolute path, convert it to something that will work below.
+            if (dirToSkip.startsWith(File.separator)) {
+                dirToSkip = dirToSkip.substring(1);
+            }
+
+            // Now we can simply check if the file's absolute path contains this directory name,
+            // with separators on either side to avoid false positives.
+            if (file.getAbsolutePath().contains(File.separator + dirToSkip + File.separator)) {
+                log.fine("Skipping file by request: " + file.getAbsolutePath());
+                return true;
+            }
+        }
+
+        // And if we get here, nothing matched, so the file should NOT be skipped:
+        return false;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/ui/SnotesPanel.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/ui/SnotesPanel.java
@@ -1,8 +1,15 @@
-package ca.corbett.crypttext.extensions.ui;
+package ca.corbett.crypttext.extensions.snotes.ui;
 
+import ca.corbett.crypttext.extensions.snotes.SnotesExtension;
+import ca.corbett.crypttext.extensions.snotes.threads.SnotesLoaderThread;
+import ca.corbett.crypttext.ui.MainWindow;
 import ca.corbett.extras.LookAndFeelManager;
+import ca.corbett.extras.progress.MultiProgressDialog;
+import ca.corbett.extras.progress.SimpleProgressAdapter;
 
+import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
@@ -31,11 +38,16 @@ import java.awt.Dimension;
 public class SnotesPanel extends JPanel implements ChangeListener {
 
     private static final int PANEL_WIDTH = 210; // maybe make this configurable
+    private final SnotesExtension extension;
 
-    public SnotesPanel() {
+    public SnotesPanel(SnotesExtension owner) {
         setMinimumSize(new Dimension(PANEL_WIDTH, 1));
         setPreferredSize(new Dimension(PANEL_WIDTH, 1));
+        this.extension = owner;
         add(new JLabel("TODO")); // just getting the panel into place for now...
+        JButton tempButton = new JButton("Load all");
+        tempButton.addActionListener(e -> testLoad());
+        add(tempButton);
     }
 
     /**
@@ -61,5 +73,40 @@ public class SnotesPanel extends JPanel implements ChangeListener {
     @Override
     public void stateChanged(ChangeEvent e) {
         SwingUtilities.updateComponentTreeUI(this);
+    }
+
+    /**
+     * This is temporary code until we get a proper UI built for this extension.
+     * Right now I just want to test our loader thread and see if we can load content.
+     */
+    private void testLoad() {
+        SnotesLoaderThread loaderThread = new SnotesLoaderThread(extension.getConfiguredDataDirectory());
+        loaderThread.addProgressListener(new TempListener(loaderThread));
+        MultiProgressDialog dialog = new MultiProgressDialog(MainWindow.getInstance(), "Loading...");
+        dialog.runWorker(loaderThread, true);
+    }
+
+    /**
+     * This will be removed once our UI is in place. Just for testing the model and IO code.
+     */
+    private class TempListener extends SimpleProgressAdapter {
+        private final SnotesLoaderThread thread;
+
+        public TempListener(SnotesLoaderThread thread) {
+            this.thread = thread;
+        }
+
+        @Override
+        public void progressComplete() {
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), "Load complete! Loaded "
+                    + thread.getSearchResults().size() + " notes.");
+        }
+
+        @Override
+        public void progressCanceled() {
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), "Oh no! Load was canceled. I got "
+                    + thread.getSearchResults().size() + " notes before I was interrupted.");
+
+        }
     }
 }

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIOTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIOTest.java
@@ -1,0 +1,121 @@
+package ca.corbett.crypttext.extensions.snotes.io;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.crypttext.extensions.snotes.model.Tag;
+import ca.corbett.crypttext.extensions.snotes.model.YMDDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SnotesIOTest {
+
+	@Test
+	public void loadNote_withDateTagsAndText_shouldPopulateModelAndMarkClean(@TempDir Path tempDir) throws IOException {
+		Path noteFile = tempDir.resolve("dated-note.snote");
+		Files.write(noteFile, List.of("#1997-04-21 #work #project", "", "Line one", "Line two"));
+
+		Note loaded = SnotesIO.loadNote(noteFile.toFile());
+
+		assertNotNull(loaded);
+		assertEquals(noteFile.toFile(), loaded.getSourceFile());
+		assertTrue(loaded.hasDate());
+		assertEquals("1997-04-21", loaded.getDate().toString());
+		assertTrue(loaded.hasTag(new Tag("work")));
+		assertTrue(loaded.hasTag(new Tag("project")));
+		assertEquals("Line one" + System.lineSeparator() + "Line two" + System.lineSeparator(), loaded.getText());
+		assertFalse(loaded.isDirty());
+	}
+
+	@Test
+	public void loadNote_withNoTagLineMarkers_shouldLoadAsUntagged(@TempDir Path tempDir) throws IOException {
+		Path noteFile = tempDir.resolve("untagged-note.snote");
+		Files.write(noteFile, List.of("this is not a tag line", "", "Body text"));
+
+		Note loaded = SnotesIO.loadNote(noteFile.toFile());
+
+		assertFalse(loaded.hasDate());
+		assertTrue(loaded.getTags().isEmpty());
+		assertEquals("Body text" + System.lineSeparator(), loaded.getText());
+		assertFalse(loaded.isDirty());
+	}
+
+	@Test
+	public void loadNote_withNullOrMissingFile_shouldThrowIOException(@TempDir Path tempDir) {
+		assertThrows(IOException.class, () -> SnotesIO.loadNote(null));
+		assertThrows(IOException.class, () -> SnotesIO.loadNote(tempDir.resolve("missing.snote").toFile()));
+	}
+
+	@Test
+	public void loadNote_withEmptyFile_shouldThrowIOException(@TempDir Path tempDir) throws IOException {
+		Path noteFile = tempDir.resolve("empty.snote");
+		Files.createFile(noteFile);
+
+		assertThrows(IOException.class, () -> SnotesIO.loadNote(noteFile.toFile()));
+	}
+
+	@Test
+	public void loadNote_withMultipleDateTags_shouldThrowIOException(@TempDir Path tempDir) throws IOException {
+		Path noteFile = tempDir.resolve("bad-dates.snote");
+		Files.write(noteFile, List.of("#1997-04-21 #2025-01-01 #work", "", "text"));
+
+		assertThrows(IOException.class, () -> SnotesIO.loadNote(noteFile.toFile()));
+	}
+
+	@Test
+	public void saveNote_withValidNote_shouldWriteFileAndMarkClean(@TempDir Path tempDir) throws IOException {
+		Path noteFile = tempDir.resolve("save-ok.snote");
+		Note note = new Note();
+		note.setSourceFile(noteFile.toFile());
+		note.setDate(new YMDDate("1997-04-21"));
+		note.tag("work");
+		note.tag("project");
+		note.setText("Line one" + System.lineSeparator() + "Line two");
+
+		assertTrue(note.isDirty());
+
+		SnotesIO.saveNote(note);
+
+		assertTrue(Files.exists(noteFile));
+		assertFalse(note.isDirty());
+
+		String fileContents = Files.readString(noteFile);
+		assertTrue(fileContents.startsWith(note.getPersistenceTagLine() + System.lineSeparator() + System.lineSeparator()));
+		assertTrue(fileContents.contains("Line one"));
+		assertTrue(fileContents.contains("Line two"));
+	}
+
+	@Test
+	public void saveNote_withNullNote_shouldThrowIllegalArgumentException() {
+		assertThrows(IllegalArgumentException.class, () -> SnotesIO.saveNote(null));
+	}
+
+	@Test
+	public void saveNote_withNoSourceFile_shouldThrowIllegalArgumentException() {
+		Note note = new Note();
+		note.setText("hello");
+
+		assertThrows(IllegalArgumentException.class, () -> SnotesIO.saveNote(note));
+	}
+
+	@Test
+	public void saveNote_withDirectoryAsTarget_shouldThrowIOException(@TempDir Path tempDir) {
+		Note note = new Note();
+		File directory = tempDir.toFile();
+		note.setSourceFile(directory);
+		note.setText("hello");
+
+		assertThrows(IOException.class, () -> SnotesIO.saveNote(note));
+	}
+
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/DateTagTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/DateTagTest.java
@@ -1,0 +1,59 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DateTagTest {
+
+    private static LocalDate today;
+
+    @BeforeAll
+    public static void setup() {
+        // We need to capture today's date at the start of the test suite, so that we can
+        // compare it against the YMDDate values that are created during the tests.
+        // This might cause problems if the test starts immediately before midnight...
+        today = LocalDate.now();
+    }
+
+    @Test
+    public void constructor_withValidDateString_shouldSetDate() {
+        DateTag dateTag = new DateTag("1997-04-21");
+        assertEquals("1997-04-21", dateTag.getTag());
+        assertEquals("#1997-04-21", dateTag.toString());
+    }
+
+    @Test
+    public void constructor_withInvalidDateString_shouldDefaultToToday() {
+        DateTag dateTag = new DateTag("invalid-date");
+        assertEquals(today.toString(), dateTag.getTag());
+        assertEquals("#" + today.toString(), dateTag.toString());
+    }
+
+    @Test
+    public void compareTo_otherDateTag_shouldCompareByDate() {
+        DateTag dateTag1 = new DateTag("1997-04-21");
+        DateTag dateTag2 = new DateTag("2000-01-01");
+        assertTrue(dateTag1.compareTo(dateTag2) < 0);
+        assertTrue(dateTag2.compareTo(dateTag1) > 0);
+    }
+
+    @Test
+    public void compareTo_nonDateTag_shouldFallbackToDefaultComparison() {
+        DateTag dateTag = new DateTag("1997-04-21");
+        Tag otherTag = new Tag("some-tag");
+        assertTrue(dateTag.compareTo(otherTag) < 0);
+        assertTrue(otherTag.compareTo(dateTag) > 0);
+    }
+
+    @Test
+    public void copyConstructor_withNull_shouldDefaultToToday() {
+        DateTag dateTag = new DateTag((DateTag)null);
+        assertEquals(today.toString(), dateTag.getTag());
+        assertEquals("#" + today.toString(), dateTag.toString());
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/NoteTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/NoteTest.java
@@ -1,6 +1,7 @@
 package ca.corbett.crypttext.extensions.snotes.model;
 
 import org.junit.jupiter.api.Test;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,18 +56,24 @@ class NoteTest {
 
     @Test
     public void getHumanTagLine_withDateAndTags_shouldReturnCorrectFormat() {
-        // GIVEN a Note with a date tag and some non-date tags:
-        Note note = new Note();
-        note.setDate(new YMDDate("1997-04-21"));
-        note.tag("tag1");
-        note.tag("tag2");
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ENGLISH);
+            // GIVEN a Note with a date tag and some non-date tags:
+            Note note = new Note();
+            note.setDate(new YMDDate("1997-04-21"));
+            note.tag("tag1");
+            note.tag("tag2");
 
-        // WHEN we get the human-readable tag line:
-        String tagLine = note.getHumanTagLine();
+            // WHEN we get the human-readable tag line:
+            String tagLine = note.getHumanTagLine();
 
-        // THEN it should be in the correct format:
-        // (this test will only work if the locale is English...)
-        assertEquals("#1997-04-21 (Monday) #tag1 #tag2" + System.lineSeparator(), tagLine);
+            // THEN it should be in the correct format:
+            // (this test will only work if the locale is English...)
+            assertEquals("#1997-04-21 (Monday) #tag1 #tag2" + System.lineSeparator(), tagLine);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @Test

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/NoteTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/NoteTest.java
@@ -1,0 +1,86 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NoteTest {
+
+    @Test
+    public void constructor_shouldCreateUntaggedNote() {
+        // WHEN we construct a Note and give it no tags at all:
+        Note note = new Note();
+
+        // THEN the Note should have no tags, no date, no text, no source file, and should not be dirty:
+        assertFalse(note.hasDate());
+        assertEquals(0, note.getNonDateTags().size());
+        assertFalse(note.isDirty());
+        assertNull(note.getSourceFile());
+        assertFalse(note.isDirty());
+    }
+
+    @Test
+    public void setDate_withValidDate_shouldSetDateTagAndDirty() {
+        // GIVEN a Note with no date tag:
+        Note note = new Note();
+
+        // WHEN we set a valid date on the Note:
+        note.setDate(new YMDDate("1997-04-21"));
+
+        // THEN the Note should have a date tag with the correct value, and should be dirty:
+        assertTrue(note.hasDate());
+        assertNotNull(note.getDate());
+        assertEquals("1997-04-21", note.getDate().toString());
+        assertTrue(note.isDirty());
+    }
+
+    @Test
+    public void setText_withText_shouldSetTextAndDirty() {
+        // GIVEN a Note with no text:
+        Note note = new Note();
+
+        // WHEN we set some text on the Note:
+        note.setText("This is some sample text.");
+
+        // THEN the Note should have the correct text, and should be dirty:
+        assertTrue(note.hasText());
+        assertNotNull(note.getText());
+        assertEquals("This is some sample text.", note.getText());
+        assertTrue(note.isDirty());
+    }
+
+    @Test
+    public void getHumanTagLine_withDateAndTags_shouldReturnCorrectFormat() {
+        // GIVEN a Note with a date tag and some non-date tags:
+        Note note = new Note();
+        note.setDate(new YMDDate("1997-04-21"));
+        note.tag("tag1");
+        note.tag("tag2");
+
+        // WHEN we get the human-readable tag line:
+        String tagLine = note.getHumanTagLine();
+
+        // THEN it should be in the correct format:
+        // (this test will only work if the locale is English...)
+        assertEquals("#1997-04-21 (Monday) #tag1 #tag2" + System.lineSeparator(), tagLine);
+    }
+
+    @Test
+    public void getPersistenceTagLine_withDateAndTags_shouldReturnCorrectFormat() {
+        // GIVEN a Note with a date tag and some non-date tags:
+        Note note = new Note();
+        note.setDate(new YMDDate("1997-04-21"));
+        note.tag("tag1");
+        note.tag("tag2");
+
+        // WHEN we get the persistence tag line:
+        String tagLine = note.getPersistenceTagLine();
+
+        // THEN it should be in the correct format:
+        assertEquals("#1997-04-21 #tag1 #tag2", tagLine);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagListTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagListTest.java
@@ -38,7 +38,7 @@ class TagListTest {
         assertTrue(tagList.hasDate());
 
         // AND the date should match today's date:
-        assertEquals(today, tagList.getDateTag().dateTag.date);
+        assertEquals(today.toString(), tagList.getDateTag().getDate().toString());
     }
 
     @Test

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagListTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagListTest.java
@@ -1,0 +1,193 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TagListTest {
+
+    private static LocalDate today;
+
+    @BeforeAll
+    public static void setup() {
+        // We need to capture today's date at the start of the test suite, so that we can
+        // compare it against the YMDDate values that are created during the tests.
+        // This might cause problems if the test starts immediately before midnight...
+        today = LocalDate.now();
+    }
+
+    @Test
+    public void noArgConstructor_shouldCreateUndatedList() {
+        TagList tagList = new TagList();
+        assertFalse(tagList.hasDate());
+    }
+
+    @Test
+    public void constructor_withNull_shouldCreateDatedList() {
+        // WHEN we pass null to the constructor:
+        TagList tagList = new TagList(null);
+
+        // THEN we should get a TagList that has a date tag:
+        assertTrue(tagList.hasDate());
+
+        // AND the date should match today's date:
+        assertEquals(today, tagList.getDateTag().dateTag.date);
+    }
+
+    @Test
+    public void setDate_withNull_shouldRemoveDate() {
+        // GIVEN a TagList with a date:
+        TagList tagList = new TagList(new YMDDate("1997-04-21"));
+        assertTrue(tagList.hasDate());
+
+        // WHEN we set the date to null:
+        tagList.setDate((String)null);
+
+        // THEN the TagList should no longer have a date:
+        assertFalse(tagList.hasDate());
+    }
+
+    @Test
+    public void addTag_withDateTag_shouldSetDate() {
+        // GIVEN a TagList with no date:
+        TagList tagList = new TagList();
+        assertFalse(tagList.hasDate());
+
+        // WHEN we add a tag that looks like a date:
+        tagList.addTag("1997-04-21");
+
+        // THEN the TagList should now have a date:
+        assertTrue(tagList.hasDate());
+    }
+
+    @Test
+    public void size_withVariousContents_shouldReturnCorrectSize() {
+        // GIVEN an empty TagList:
+        TagList tagList = new TagList();
+        assertEquals(0, tagList.size());
+
+        // WHEN we add a normal tag, THEN the size should be 1:
+        tagList.addTag("some-tag");
+        assertEquals(1, tagList.size());
+
+        // WHEN we add a date tag, THEN the size should be 2 (combined size):
+        tagList.addTag("1997-04-21");
+        assertEquals(2, tagList.size());
+
+        // WHEN we add another normal tag, THEN the size should be 3:
+        tagList.addTag("another-tag");
+        assertEquals(3, tagList.size());
+
+        // WHEN we set date to null, THEN the size should decrease by 1:
+        tagList.setDate((String)null);
+        assertEquals(2, tagList.size());
+    }
+
+    @Test
+    public void removeTag_withNonExistentTag_shouldHaveNoEffect() {
+        // GIVEN a TagList with some tags:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+        assertEquals(2, tagList.size());
+
+        // WHEN we try to remove a tag that isn't in the list:
+        tagList.removeTag("non-existent-tag");
+
+        // THEN the size should remain unchanged:
+        assertEquals(2, tagList.size());
+    }
+
+    @Test
+    public void removeTag_withDateString_shouldRemoveDateTag() {
+        // GIVEN a TagList with a date tag:
+        TagList tagList = new TagList();
+        tagList.addTag("1997-04-21");
+        assertTrue(tagList.hasDate());
+
+        // WHEN we remove the date tag using its string representation:
+        tagList.removeTag("1997-04-21");
+
+        // THEN the TagList should no longer have a date:
+        assertFalse(tagList.hasDate());
+    }
+
+    @Test
+    public void removeTag_withNormalTag_shouldRemoveThatTag() {
+        // GIVEN a TagList with some normal tags:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+        assertEquals(2, tagList.size());
+
+        // WHEN we remove one of the normal tags:
+        tagList.removeTag("tag1");
+
+        // THEN the size should decrease by 1:
+        assertEquals(1, tagList.size());
+    }
+
+    @Test
+    public void hasTag_withValidValues_shouldReturnTrue() {
+        // GIVEN a TagList with some tags:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+        tagList.addTag("1997-04-21"); // This should be treated as a date tag, not a normal tag
+
+        // THEN hasTag should return true for those tags:
+        assertTrue(tagList.hasTag("tag1"));
+        assertTrue(tagList.hasTag("tag2"));
+        assertTrue(tagList.hasTag("1997-04-21")); // This should return true because it's a date tag
+        assertTrue(tagList.hasTag(new DateTag("1997-04-21"))); // This should also return true
+    }
+
+    @Test
+    public void hasTag_withNonExistentTag_shouldReturnFalse() {
+        // GIVEN a TagList with some tags:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+
+        // THEN hasTag should return false for a tag that isn't in the list:
+        assertFalse(tagList.hasTag("non-existent-tag"));
+    }
+
+    @Test
+    public void getNonDateTags_shouldExcludeDateTag() {
+        // GIVEN a TagList with some normal tags and a date tag:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+        tagList.addTag("1997-04-21"); // This should be treated as a date tag
+
+        // THEN getNonDateTags should return only the normal tags, not the date tag:
+        assertTrue(tagList.getNonDateTags().contains(new Tag("tag1")));
+        assertTrue(tagList.getNonDateTags().contains(new Tag("tag2")));
+        assertFalse(tagList.getNonDateTags().contains(new DateTag("1997-04-21")));
+    }
+
+    @Test
+    public void getTags_withValidList_shouldReturnAllTagsWithDateFirst() {
+        // GIVEN a TagList with some normal tags and a date tag:
+        TagList tagList = new TagList();
+        tagList.addTag("tag1");
+        tagList.addTag("tag2");
+        tagList.addTag("1997-04-21"); // This should be treated as a date tag
+
+        // THEN getTags should return all tags, with the date tag first:
+        List<Tag> actualTags = tagList.getTags();
+        assertEquals(3, actualTags.size());
+        assertInstanceOf(DateTag.class, actualTags.get(0)); // date should be first!
+        assertEquals("1997-04-21", tagList.getTags().get(0).getTag());
+        assertEquals(1, actualTags.indexOf(new Tag("tag1")));
+        assertEquals(2, actualTags.indexOf(new Tag("tag2")));
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/TagTest.java
@@ -1,0 +1,98 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TagTest {
+
+    @Test
+    public void constructor_withValidValue_shouldReturnAsIs() {
+        // GIVEN a perfectly valid tag value:
+        final String input = "valid_tag";
+
+        // WHEN we pass it to the constructor:
+        Tag actual = new Tag(input);
+
+        // THEN the tag value should be identical to the input:
+        assertEquals(input, actual.getTag());
+    }
+
+    @Test
+    public void constructor_withLeadingTrailingWhitespace_shouldTrim() {
+        // GIVEN a tag value with leading and trailing whitespace:
+        final String input = "  valid_tag  ";
+
+        // WHEN we pass it to the constructor:
+        Tag actual = new Tag(input);
+
+        // THEN the tag value should be trimmed of whitespace:
+        assertEquals("valid_tag", actual.getTag());
+    }
+
+    @Test
+    public void constructor_withIllegalCharacters_shouldReplaceWithUnderscores() {
+        // GIVEN a tag value with spaces and slashes:
+        final String input = "  invalid tag/with\\illegal characters  ";
+
+        // WHEN we pass it to the constructor:
+        Tag actual = new Tag(input);
+
+        // THEN the tag value should have spaces and slashes replaced with underscores:
+        assertEquals("invalid_tag_with_illegal_characters", actual.getTag());
+    }
+
+    @Test
+    public void constructor_withNullOrEmptyValue_shouldThrow() {
+        // GIVEN a null tag value:
+        final String input = null;
+
+        // WHEN we pass it to the constructor, THEN it should throw an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> new Tag(input));
+    }
+
+    @Test
+    public void constructor_withEmptyString_shouldThrow() {
+        // GIVEN an empty tag value:
+        final String input = "   ";
+
+        // WHEN we pass it to the constructor, THEN it should throw an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> new Tag(input));
+    }
+
+    @Test
+    public void compareTo_withMultipleTags_shouldSort() {
+        // GIVEN a list of tags in random order:
+        Tag tag1 = new Tag("zzz_last");
+        Tag tag2 = new Tag("eee_middle");
+        Tag tag3 = new Tag("aaa_first");
+        Tag tag4 = new Tag("ggg_random");
+
+        // WHEN we sort them:
+        List<Tag> tags = Arrays.asList(tag1, tag2, tag3, tag4);
+        Collections.sort(tags);
+
+        // THEN they should be sorted alphabetically by their tag value:
+        assertEquals("aaa_first", tags.get(0).getTag());
+        assertEquals("eee_middle", tags.get(1).getTag());
+        assertEquals("ggg_random", tags.get(2).getTag());
+        assertEquals("zzz_last", tags.get(3).getTag());
+    }
+
+    @Test
+    public void toString_withValidTag_shouldReturnHashPrefixed() {
+        // GIVEN a valid tag:
+        Tag tag = new Tag("example");
+
+        // WHEN we call toString():
+        String actual = tag.toString();
+
+        // THEN it should return the tag value prefixed with a hash sign:
+        assertEquals("#example", actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -86,11 +87,18 @@ class YMDDateTest {
     @Test
     public void getDayName_withValidDate_shouldReturnCorrectDayName() {
         // GIVEN a YMDDate representing April 21, 1997:
-        YMDDate date = new YMDDate(testDate);
+        Locale previousLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ENGLISH);
 
-        // THEN getDayName should return "Monday":
-        // (this test will only work if the default locale is English...)
-        assertEquals("Monday", date.getDayName());
+            YMDDate date = new YMDDate(testDate);
+
+            // THEN getDayName should return "Monday" in the English locale:
+            assertEquals("Monday", date.getDayName());
+        } finally {
+            // Restore the original default locale so other tests are not affected:
+            Locale.setDefault(previousLocale);
+        }
     }
 
     @Test

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
@@ -37,7 +37,7 @@ class YMDDateTest {
         YMDDate date = new YMDDate();
 
         // THEN the date should be set to the current date:
-        assertEquals(today, date.date);
+        assertEquals(today.toString(), date.toString());
     }
 
     @Test
@@ -51,7 +51,7 @@ class YMDDateTest {
             YMDDate date = new YMDDate("invalid-date");
 
             // THEN the date should default to today:
-            assertEquals(today, date.date);
+            assertEquals(today.toString(), date.toString());
 
             // AND a warning should have been logged with "invalid date":
             assertTrue(handler.hasWarningContaining("invalid date"));

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/YMDDateTest.java
@@ -1,0 +1,166 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YMDDateTest {
+
+    private static LocalDate testDate;
+    private static LocalDate today;
+
+    @BeforeAll
+    public static void setup() {
+        // We need to capture today's date at the start of the test suite, so that we can
+        // compare it against the YMDDate values that are created during the tests.
+        // This might cause problems if the test starts immediately before midnight...
+        today = LocalDate.now();
+
+        // We'll pick an arbitrary test date of Monday, April 21, 1997, for testing:
+        testDate = LocalDate.of(1997, 4, 21);
+    }
+
+    @Test
+    public void noArgsConstructor_shouldSetCurrentDate() {
+        // GIVEN a YMDDate with no arguments:
+        YMDDate date = new YMDDate();
+
+        // THEN the date should be set to the current date:
+        assertEquals(today, date.date);
+    }
+
+    @Test
+    public void constructor_withInvalidDate_shouldDefaultToTodayAndLogWarning() {
+        TestLogHandler handler = new TestLogHandler();
+        Logger logger = Logger.getLogger(YMDDate.class.getName());
+        logger.addHandler(handler);
+
+        try {
+            // GIVEN a YMDDate with an invalid date string:
+            YMDDate date = new YMDDate("invalid-date");
+
+            // THEN the date should default to today:
+            assertEquals(today, date.date);
+
+            // AND a warning should have been logged with "invalid date":
+            assertTrue(handler.hasWarningContaining("invalid date"));
+        }
+        finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    public void isValidYMD_withValidValues_shouldReturnTrue() {
+        // GIVEN some valid YMD date strings:
+        String[] validDates = {"2024-01-01", "2024-12-31", "2024-02-29"};
+
+        // THEN isValidYMD should return true for all of them:
+        for (String dateStr : validDates) {
+            assertTrue(YMDDate.isValidYMD(dateStr), "Expected '" + dateStr + "' to be valid");
+        }
+    }
+
+    @Test
+    public void isValidYMD_withInvalidValues_shouldReturnFalse() {
+        // GIVEN some invalid YMD date strings:
+        String[] invalidDates = {"2024-13-01", "2024-00-10", "2024-02-30", "not-a-date", "", null};
+
+        // THEN isValidYMD should return false for all of them:
+        for (String dateStr : invalidDates) {
+            assertFalse(YMDDate.isValidYMD(dateStr), "Expected '" + dateStr + "' to be invalid");
+        }
+    }
+
+    @Test
+    public void getDayName_withValidDate_shouldReturnCorrectDayName() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getDayName should return "Monday":
+        // (this test will only work if the default locale is English...)
+        assertEquals("Monday", date.getDayName());
+    }
+
+    @Test
+    public void getTomorrow_withValidDate_shouldReturnNextDay() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getTomorrow should return April 22, 1997:
+        assertEquals(LocalDate.of(1997, 4, 22), date.getTomorrow().date);
+    }
+
+    @Test
+    public void getYesterday_withValidDate_shouldReturnPreviousDay() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getYesterday should return April 20, 1997:
+        assertEquals(LocalDate.of(1997, 4, 20), date.getYesterday().date);
+    }
+
+    @Test
+    public void getYearStr_withValidDate_shouldReturnFourDigitYear() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getYearStr should return "1997":
+        assertEquals("1997", date.getYearStr());
+    }
+
+    @Test
+    public void getMonthStr_withValidDate_shouldReturnTwoDigitMonth() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getMonthStr should return "04" and NOT "4"!:
+        assertEquals("04", date.getMonthStr());
+    }
+
+    @Test
+    public void getDayStr_withValidDate_shouldReturnTwoDigitDay() {
+        // GIVEN a YMDDate representing April 21, 1997:
+        YMDDate date = new YMDDate(testDate);
+
+        // THEN getDayStr should return "21":
+        assertEquals("21", date.getDayStr());
+    }
+
+    /**
+     * This test class can be used to intercept log warnings.
+     */
+    static class TestLogHandler extends Handler {
+        private final List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        public boolean hasWarningContaining(String message) {
+            return records.stream()
+                          .anyMatch(r -> r.getLevel() == Level.WARNING &&
+                                  r.getMessage().toLowerCase().contains(message.toLowerCase()));
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses issue #2 by adding model and IO classes, with unit tests.

- Moved all code into new `snotes` package for better organization
- Added model classes for `Tag`, `TagList`, `DateTag`, `YMDDate`, and `Note`
- Notably absent are `Query` and `Template`, but as they are more complicated, they will each be handled by separate future tickets.
- Added IO helper classes `SnotesIO` and `SnotesLoaderThread`
- Added comprehensive unit tests
- Added configuration property for the data directory.
- Added very basic (and very temporary) code in the UI for a quick test with real data.

Unrelated to this PR: changed target Java version from 21 to 17 to match the parent application. (21 was a mistake when this project was set up)