### PR TITLE
Issue #7 implement Query and filters

### DIFF
--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/io/SnotesIO.java
@@ -102,6 +102,21 @@ public class SnotesIO {
             throw new IllegalArgumentException("Cannot save a Note with no source file.");
         }
 
+        // TODO this is wrong!
+        //      Dated notes require special handling, as they automatically go into folders
+        //      based on the date, like 2021/01/09/note.txt
+        //      If it's a first-time save, we have to compute that path.
+        //      If it's an existing note, we have to check to see if the location is still good, and update it if not.
+        //      Undated notes typically go into a "static" or "undated" folder, but we are not yet
+        //      exposing that config property.
+        //      All Notes, dated or not, get an automatic filename based on their tag list.
+        //      Need to circle back to this in a future ticket! We're not handling any of it right now!
+        //      And don't forget the "append if existing" option from the original application!
+        //      e.g. create a new dated note with a tag of "tag" and save it when one already exists for that date...
+        //           user should be prompted to append to or overwrite the existing note, and the code should be
+        //           smart enough to do the right thing.
+        //      The code for all of the above exists in the old Mercurial repo. Dig it up and reuse it!
+
         List<String> lines = new ArrayList<>();
         lines.add(note.getPersistenceTagLine());
         lines.add(""); // blank line between tags and text is conventional.

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/DateTag.java
@@ -40,10 +40,10 @@ public final class DateTag extends Tag {
     }
 
     /**
-     * Returns a copy of the YMDDate object that this tag represents.
+     * Returns the YMDDate object that this tag represents.
      */
     public YMDDate getDate() {
-        return new YMDDate(dateTag.toString());
+        return dateTag; // it's immutable, so we can just return the reference
     }
 
     @Override

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Note.java
@@ -70,20 +70,24 @@ public final class Note {
      * Passing null will convert this Note to an undated one.
      *
      * @param date The new YMDDate for this Note, or null for no date.
+     * @return This Note, for chaining.
      */
-    public void setDate(YMDDate date) {
+    public Note setDate(YMDDate date) {
         tagList.setDate(date);
         isDirty = true;
+        return this;
     }
 
     /**
      * Replaces any existing text for this Note with the given text.
      *
      * @param newText The new text value for this Note.
+     * @return This Note, for chaining.
      */
-    public void setText(String newText) {
+    public Note setText(String newText) {
         text = newText == null ? "" : newText;
         isDirty = true;
+        return this;
     }
 
     /**
@@ -92,18 +96,23 @@ public final class Note {
      * newline characters in newText.
      *
      * @param newText The text to append to this Note.
+     * @return This Note, for chaining.
      */
-    public void append(String newText) {
+    public Note append(String newText) {
         text += newText;
         isDirty = true;
+        return this;
     }
 
     /**
      * Appends a System-specific newline character to this Note.
+     *
+     * @return This Note, for chaining.
      */
-    public void newline() {
+    public Note newline() {
         text += System.lineSeparator();
         isDirty = true;
+        return this;
     }
 
     /**
@@ -163,42 +172,50 @@ public final class Note {
      * If the given Tag is a DateTag, this is equivalent to calling setDate()
      *
      * @param tag The Tag to add.
+     * @return This Note, for chaining.
      */
-    public void tag(Tag tag) {
+    public Note tag(Tag tag) {
         tagList.addTag(tag);
         isDirty = true;
+        return this;
     }
 
     /**
      * Adds the specified tag value to this Note, if not already present. Duplicate tags are ignored.
      *
      * @param tag The tag value to add.
+     * @return This Note, for chaining.
      */
-    public void tag(String tag) {
+    public Note tag(String tag) {
         tagList.addTag(tag);
         isDirty = true;
+        return this;
     }
 
     /**
      * Removes the given tag from this Note, if present.
      *
      * @param tag The tag to remove.
+     * @return This Note, for chaining.
      */
-    public void untag(String tag) {
+    public Note untag(String tag) {
         if (tagList.removeTag(tag)) {
             isDirty = true;
         }
+        return this;
     }
 
     /**
      * Removes the given tag from this Note, if present.
      *
      * @param tag The tag to remove.
+     * @return This Note, for chaining.
      */
-    public void untag(Tag tag) {
+    public Note untag(Tag tag) {
         if (tagList.removeTag(tag)) {
             isDirty = true;
         }
+        return this;
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Query.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Query.java
@@ -118,6 +118,9 @@ public class Query {
      * @return A new list of Notes that passed through all the filters in this Query. May be empty, but never null.
      */
     public List<Note> filter(List<Note> notes) {
+        if (notes == null) {
+            return new ArrayList<>();
+        }
         List<Note> filteredNotes = new ArrayList<>();
         for (Note note : notes) {
             boolean isFiltered = false;

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Query.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/Query.java
@@ -1,0 +1,136 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import ca.corbett.crypttext.extensions.snotes.model.filter.Filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Query is a collection of zero or more Filter instances that can be applied
+ * to a list of Notes to produce a filtered list.
+ * <p>
+ * Note that all Filters in the chain are "and"ed together. There
+ * is currently no way to "or" filters together, or to have more complex logic like
+ * "filter A and (filter B or filter C)".
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class Query {
+
+    public static final String DEFAULT_NAME = "Unnamed Query";
+    public static final int NAME_LENGTH_LIMIT = 25;
+
+    private String name;
+    private final List<Filter> filters;
+
+    /**
+     * Creates an empty, unnamed Query with no filters.
+     * In this configuration, the Query will always return a completely unfiltered list of Notes when applied.
+     * Use addFilter() to add filters to this Query and make it more selective.
+     */
+    public Query() {
+        this.filters = new ArrayList<>();
+        name = DEFAULT_NAME;
+    }
+
+    /**
+     * Returns the name of this Query, or DEFAULT_NAME if no name has been set.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets an optional name for this Query. It should be short and user-presentable.
+     * If longer than NAME_LENGTH_LIMIT, the name will be truncated to that length.
+     * If null or blank, the name will be set to DEFAULT_NAME.
+     */
+    public Query setName(String name) {
+        if (name == null || name.isBlank()) {
+            name = DEFAULT_NAME;
+        }
+        if (name.length() > NAME_LENGTH_LIMIT) {
+            name = name.substring(0, NAME_LENGTH_LIMIT);
+        }
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Returns true if there are no Filters in this Query.
+     */
+    public boolean isEmpty() {
+        return filters.isEmpty();
+    }
+
+    /**
+     * Returns a count of Filters in this Query.
+     */
+    public int size() {
+        return filters.size();
+    }
+
+    /**
+     * Removes all Filters from this Query, and returns it to an empty state.
+     * An empty Query will return a completely unfiltered list of Notes when applied.
+     */
+    public void clear() {
+        filters.clear();
+    }
+
+    /**
+     * Adds a Filter to this Query. Filters are applied in the order they are added.
+     * Note that there is no code here to check that the given Filters make sense
+     * and don't conflict with one another. For example, you could add a DateFilter
+     * of "before 2010" and another DateFilter of "after 2015" to the same Query.
+     * This is technically valid, but will filter out all Notes.
+     */
+    public Query addFilter(Filter filter) {
+        if (filter == null) {
+            throw new IllegalArgumentException("Cannot add a null Filter to a Query.");
+        }
+        filters.add(filter);
+        return this;
+    }
+
+    /**
+     * Removes the given Filter from this Query, if it is present.
+     */
+    public Query removeFilter(Filter filter) {
+        filters.remove(filter);
+        return this;
+    }
+
+    /**
+     * Returns a copy of the list of Filters in this Query.
+     */
+    public List<Filter> getFilters() {
+        return new ArrayList<>(filters); // Return a copy to prevent external modification
+    }
+
+    /**
+     * Applies our chain of filters to the provided list of Notes, returning a new list that only contains
+     * Notes that were not filtered out by any of the filters in this Query.
+     * The resulting list may be empty if the filters are too strict, but it will never be null.
+     *
+     * @param notes The list of Notes to filter. This list is not modified by this method.
+     * @return A new list of Notes that passed through all the filters in this Query. May be empty, but never null.
+     */
+    public List<Note> filter(List<Note> notes) {
+        List<Note> filteredNotes = new ArrayList<>();
+        for (Note note : notes) {
+            boolean isFiltered = false;
+            for (Filter filter : filters) {
+                if (filter.isFiltered(note)) {
+                    isFiltered = true;
+                    break; // No need to check other filters if one already filters this note
+                }
+            }
+            if (!isFiltered) {
+                filteredNotes.add(note);
+            }
+        }
+        return filteredNotes;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/QueryFactory.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/QueryFactory.java
@@ -1,0 +1,64 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import ca.corbett.crypttext.extensions.snotes.model.filter.DateFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.DayOfMonthFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.MonthFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.TagFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.TextFilter;
+
+import java.util.List;
+
+/**
+ * A utility class with shorthand methods for creating common queries.
+ * The returned Query instance is not immutable! You can use these
+ * factory methods as a starting point, and add additional criteria if you want.
+ * <p>
+ * Dev note: the Query UI, once built, might make this entire class unnecessary.
+ * Users will be able to visually build out whatever Query they need.
+ * Once Query persistence is implemented, they can then save those queries for next time.
+ * For now, these can be handy code shortcuts.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class QueryFactory {
+
+    private QueryFactory() {
+    }
+
+    /**
+     * Returns a Query that looks for Notes between two dates, inclusive.
+     */
+    public static Query between(YMDDate startDate, YMDDate endDate) {
+        return new Query()
+                .addFilter(new DateFilter(startDate, DateFilter.FilterType.AFTER_INCLUSIVE))
+                .addFilter(new DateFilter(endDate, DateFilter.FilterType.BEFORE_INCLUSIVE));
+    }
+
+    /**
+     * Returns a Query that looks for Notes between two dates, inclusive, and with a specific tag.
+     */
+    public static Query between(YMDDate startDate, YMDDate endDate, String tag) {
+        return new Query()
+                .addFilter(new DateFilter(startDate, DateFilter.FilterType.AFTER_INCLUSIVE))
+                .addFilter(new DateFilter(endDate, DateFilter.FilterType.BEFORE_INCLUSIVE))
+                .addFilter(new TagFilter(List.of(new Tag(tag)), TagFilter.FilterType.ALL));
+    }
+
+    /**
+     * Returns a Query that looks for Notes on a specific date in any year.
+     * For example: specificDateAnyYear(12, 25) would return all Xmas Notes from any year.
+     */
+    public static Query specificDateAnyYear(int month, int day) {
+        return new Query()
+                .addFilter(new MonthFilter(month, MonthFilter.FilterType.IS))
+                .addFilter(new DayOfMonthFilter(day, DayOfMonthFilter.FilterType.IS));
+    }
+
+    /**
+     * Returns a very simple Query that returns all Notes that contain the given text, case-insensitive.
+     */
+    public static Query contains(String text) {
+        return new Query().addFilter(new TextFilter(text, false));
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
@@ -156,6 +156,10 @@ public class YMDDate implements Comparable<YMDDate> {
      * Returns true if this YMDDate is before the given YMDDate, false otherwise.
      */
     public boolean isBefore(YMDDate other) {
+        if (other == null) {
+            // Aligns with compareTo: this is not considered "before" a null date.
+            return false;
+        }
         return this.date.isBefore(other.date);
     }
 
@@ -163,6 +167,10 @@ public class YMDDate implements Comparable<YMDDate> {
      * Returns true if this YMDDate is after the given YMDDate, false otherwise.
      */
     public boolean isAfter(YMDDate other) {
+        if (other == null) {
+            // Aligns with compareTo: this is considered "after" a null date.
+            return true;
+        }
         return this.date.isAfter(other.date);
     }
 
@@ -170,6 +178,9 @@ public class YMDDate implements Comparable<YMDDate> {
      * Returns true if this YMDDate is the same as the given YMDDate, false otherwise.
      */
     public boolean isSameDate(YMDDate other) {
+        if (other == null) {
+            return false;
+        }
         return this.date.isEqual(other.date);
     }
 

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/YMDDate.java
@@ -1,9 +1,11 @@
 package ca.corbett.crypttext.extensions.snotes.model;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
 import java.time.format.TextStyle;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 /**
@@ -81,9 +83,21 @@ public class YMDDate implements Comparable<YMDDate> {
      * This value is NOT used for tagging purposes, but can be used when displaying
      * a dated Note to the user.
      * </p>
+     * <p>
+     * Strongly suggest to use getDayOfWeek() instead, as it is not affected by locale.
+     * </p>
      */
     public String getDayName() {
         return date.getDayOfWeek().getDisplayName(TextStyle.FULL, java.util.Locale.getDefault());
+    }
+
+    /**
+     * Returns the DayOfWeek enum value for this date. This is not affected by locale.
+     *
+     * @return The DayOfWeek enum value for this date.
+     */
+    public DayOfWeek getDayOfWeek() {
+        return date.getDayOfWeek();
     }
 
     /**
@@ -108,11 +122,55 @@ public class YMDDate implements Comparable<YMDDate> {
     }
 
     /**
+     * Returns the year as an int.
+     */
+    public int getYear() {
+        return date.getYear();
+    }
+
+    /**
+     * Returns the 1-based month as an int.
+     * Note that this is 1-based! January would be returned as "1", not "0".
+     */
+    public int getMonth() {
+        return date.getMonthValue();
+    }
+
+    /**
+     * Returns the 1-based day of month as an int.
+     * Note that this is 1-based! The first day of the month would be returns as "1", not "0".
+     */
+    public int getDayOfMonth() {
+        return date.getDayOfMonth();
+    }
+
+    /**
      * Returns a yyyy-MM-dd formatted String representation of this date.
      */
     @Override
     public String toString() {
         return date.format(FORMATTER);
+    }
+
+    /**
+     * Returns true if this YMDDate is before the given YMDDate, false otherwise.
+     */
+    public boolean isBefore(YMDDate other) {
+        return this.date.isBefore(other.date);
+    }
+
+    /**
+     * Returns true if this YMDDate is after the given YMDDate, false otherwise.
+     */
+    public boolean isAfter(YMDDate other) {
+        return this.date.isAfter(other.date);
+    }
+
+    /**
+     * Returns true if this YMDDate is the same as the given YMDDate, false otherwise.
+     */
+    public boolean isSameDate(YMDDate other) {
+        return this.date.isEqual(other.date);
     }
 
     /**
@@ -137,5 +195,16 @@ public class YMDDate implements Comparable<YMDDate> {
             return 1;
         }
         return this.date.compareTo(o.date);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof YMDDate ymdDate)) { return false; }
+        return Objects.equals(date, ymdDate.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(date);
     }
 }

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilter.java
@@ -1,0 +1,57 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.crypttext.extensions.snotes.model.YMDDate;
+
+/**
+ * This Filter can be used to filter Notes by their calendar date.
+ * The included FilterType enum can be used to specify the type of date comparison.
+ * <p>
+ * Note that the actual date comparisons are deferred to the YMDDate comparison methods.
+ * </p>
+ * <p>
+ * <B>NOTE:</B> all date filters automatically filter out undated notes.
+ * Applying any type of date filter will automatically exclude all notes that do not have a date,
+ * or whose date is null.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class DateFilter extends Filter {
+
+    public enum FilterType {
+        BEFORE_EXCLUSIVE, BEFORE_INCLUSIVE, ON, AFTER_INCLUSIVE, AFTER_EXCLUSIVE
+    }
+
+    private final YMDDate targetDate;
+    private final FilterType filterType;
+
+    public DateFilter(YMDDate targetDate, FilterType filterType) {
+        if (targetDate == null || filterType == null) {
+            throw new IllegalArgumentException("targetDate and filterType cannot be null");
+        }
+        this.targetDate = targetDate;
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by specific calendar date";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || !note.hasDate() || note.getDate() == null) {
+            // All date filters automatically filter out non-dated notes.
+            return true;
+        }
+        int comparison = note.getDate().compareTo(targetDate);
+        return switch (filterType) {
+            case BEFORE_EXCLUSIVE -> comparison >= 0;
+            case BEFORE_INCLUSIVE -> comparison > 0;
+            case ON -> comparison != 0;
+            case AFTER_INCLUSIVE -> comparison < 0;
+            case AFTER_EXCLUSIVE -> comparison <= 0;
+        };
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfMonthFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfMonthFilter.java
@@ -1,0 +1,55 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+/**
+ * This filter can be used to filter by day of month, regardless which specific month or year the note is from.
+ * For example, "I want to see all notes that were written on the 15th of any month, in any year".
+ * This can be combined with MonthFilter to say "I want to see all notes from March 15th of any year".
+ * <p>
+ * <B>NOTE:</B> all date filters automatically filter out undated notes.
+ * Applying any type of date filter will automatically exclude all notes that do not have a date,
+ * or whose date is null.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class DayOfMonthFilter extends Filter {
+
+    public enum FilterType {
+        IS, IS_NOT
+    }
+
+    private final int dayOfMonth;
+    private final FilterType filterType;
+
+    /**
+     * Creates a DayOfMonthFilter for the given 1-based day of month (1-31) and filter type.
+     */
+    public DayOfMonthFilter(int dayOfMonth, FilterType filterType) {
+        if (dayOfMonth < 1 || dayOfMonth > 31) {
+            throw new IllegalArgumentException("dayOfMonth must be between 1 and 31");
+        }
+        if (filterType == null) {
+            throw new IllegalArgumentException("filterType cannot be null");
+        }
+        this.dayOfMonth = dayOfMonth;
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by day of month in any month/year";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || !note.hasDate() || note.getDate() == null) {
+            // All date filters automatically filter out non-dated notes.
+            return true;
+        }
+        return filterType == FilterType.IS ?
+                note.getDate().getDayOfMonth() != dayOfMonth
+                : note.getDate().getDayOfMonth() == dayOfMonth;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfWeekFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfWeekFilter.java
@@ -1,0 +1,52 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+import java.time.DayOfWeek;
+
+/**
+ * This filter can be used to filter Notes based on the day of the week of their date, regardless
+ * of specific year, month, or day of month. For example, "I want to see all notes that were written
+ * on a Monday, in any month and year". This can be combined with a MonthFilter and/or a DayOfMonthFilter
+ * to say something like "show me all Notes from December 25th in any year, if it was a Wednesday".
+ * <p>
+ * <B>NOTE:</B> all date filters automatically filter out undated notes.
+ * Applying any type of date filter will automatically exclude all notes that do not have a date,
+ * or whose date is null.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class DayOfWeekFilter extends Filter {
+
+    public enum FilterType {
+        IS, IS_NOT
+    }
+
+    private final DayOfWeek dayOfWeek;
+    private final FilterType filterType;
+
+    public DayOfWeekFilter(DayOfWeek dayOfWeek, FilterType filterType) {
+        if (dayOfWeek == null || filterType == null) {
+            throw new IllegalArgumentException("dayOfWeek and filterType cannot be null");
+        }
+        this.dayOfWeek = dayOfWeek;
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by day of week";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || !note.hasDate() || note.getDate() == null) {
+            // All date filters automatically filter out non-dated notes.
+            return true;
+        }
+        return filterType == FilterType.IS ?
+                note.getDate().getDayOfWeek() != dayOfWeek
+                : note.getDate().getDayOfWeek() == dayOfWeek;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/Filter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/Filter.java
@@ -1,0 +1,23 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+/**
+ * An abstract base class for all filters. Each filter has a human-readable description,
+ * and a simple method to determine if a candidate Note should be filtered or not.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public abstract class Filter {
+
+    /**
+     * Returns a brief, human-presentable description of this filter.
+     */
+    public abstract String getDescription();
+
+    /**
+     * Return true if the given Note should be filtered (removed from the results).
+     * Return false if the given Note should be included in the results.
+     */
+    public abstract boolean isFiltered(Note note);
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/MonthFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/MonthFilter.java
@@ -1,0 +1,53 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+/**
+ * This Filter can be used to filter Notes by their month, regardless of year.
+ * For example, "I want to see all notes that were written in March, in any year".
+ * This can be combined with a DayOfMonthFilter and/or a DayOfWeekFilter to
+ * say something like "show me all Notes from December in any year, if it was the 25th and a Wednesday".
+ * <p>
+ * <B>NOTE:</B> all date filters automatically filter out undated notes.
+ * Applying any type of date filter will automatically exclude all notes that do not have a date,
+ * or whose date is null.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class MonthFilter extends Filter {
+
+    public enum FilterType {
+        IS, IS_NOT
+    }
+
+    private final int targetMonth;
+    private final FilterType filterType;
+
+    public MonthFilter(int targetMonth, FilterType filterType) {
+        if (targetMonth < 1 || targetMonth > 12) {
+            throw new IllegalArgumentException("targetMonth must be between 1 and 12");
+        }
+        if (filterType == null) {
+            throw new IllegalArgumentException("filterType cannot be null");
+        }
+        this.targetMonth = targetMonth;
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by month in any year";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || !note.hasDate() || note.getDate() == null) {
+            // All date filters automatically filter out non-dated notes.
+            return true;
+        }
+        return filterType == FilterType.IS ?
+                note.getDate().getMonth() != targetMonth
+                : note.getDate().getMonth() == targetMonth;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TagFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TagFilter.java
@@ -1,0 +1,64 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.crypttext.extensions.snotes.model.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This Filter allows you to filter Notes based on their tags.
+ * You can specify a list of tags to filter by (at least one), and a FilterType
+ * indicating the type of Tag comparison to perform.
+ * For example: "all notes containing the tags tag1 and tag2" or
+ * "all notes containing either tag1 or tag2" or "all notes that do not contain either tag1 or tag2".
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TagFilter extends Filter {
+
+    public enum FilterType {
+        ALL, ANY, NONE
+    }
+
+    private final List<Tag> tagsToFilter;
+    private final FilterType filterType;
+
+    public TagFilter(List<Tag> tagsToFilter, FilterType filterType) {
+        if (tagsToFilter == null || tagsToFilter.isEmpty()) {
+            throw new IllegalArgumentException("tagsToFilter cannot be null or empty");
+        }
+        if (filterType == null) {
+            throw new IllegalArgumentException("filterType cannot be null");
+        }
+        this.tagsToFilter = new ArrayList<>(tagsToFilter); // Defensive copy to prevent external modification
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by specific tag(s)";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        // Convert to HashSet for better performance:
+        Set<Tag> noteTags = new HashSet<>(note == null ? List.of() : note.getTags());
+
+        // Special handling for when the Note has no tags:
+        if (noteTags.isEmpty()) {
+            return switch (filterType) {
+                case ALL, ANY -> true; // Note does not contain any tags, so it fails ALL and ANY filters.
+                case NONE -> false; // If filtering for NONE, then an untagged note always passes.
+            };
+        }
+
+        return switch (filterType) {
+            case ALL -> !noteTags.containsAll(tagsToFilter);
+            case ANY -> tagsToFilter.stream().noneMatch(noteTags::contains);
+            case NONE -> tagsToFilter.stream().anyMatch(noteTags::contains);
+        };
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
@@ -55,7 +55,7 @@ public class TextFilter extends Filter {
         String toFind = contains;
         if (!isCaseSensitive) {
             candidateText = candidateText.toLowerCase(Locale.ROOT);
-            toFind = toFind.toLowerCase();
+            toFind = toFind.toLowerCase(Locale.ROOT);
         }
         return !candidateText.contains(toFind);
     }

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
@@ -39,11 +39,19 @@ public class TextFilter extends Filter {
 
     @Override
     public boolean isFiltered(Note note) {
-        if (note == null || note.getText() == null || note.getText().isBlank()) {
-            // Don't bother filtering if there's nothing to filter.
+        // If the filter text is empty, this filter is a documented no-op.
+        if (contains.isEmpty()) {
             return false;
         }
-        String candidateText = note.getText();
+        // A null note or a note with null/blank text cannot contain the target text.
+        if (note == null) {
+            return true;
+        }
+        String noteText = note.getText();
+        if (noteText == null || noteText.isBlank()) {
+            return true;
+        }
+        String candidateText = noteText;
         String toFind = contains;
         if (!isCaseSensitive) {
             candidateText = candidateText.toLowerCase(Locale.ROOT);

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilter.java
@@ -1,0 +1,54 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+import java.util.Locale;
+
+/**
+ * This Filter can be used to filter Notes by their text content.
+ * If a Note does not contain the given text (with optional case-sensitivity), then it will be filtered out.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TextFilter extends Filter {
+
+    private final String contains;
+    private final boolean isCaseSensitive;
+
+    public TextFilter(String contains) {
+        this(contains, false);
+    }
+
+    /**
+     * Create a text filter with the given text to search for, with optional case-sensitivity.
+     * The given text can be null or empty, but the resulting filter will effectively be a no-op.
+     * <p>
+     * The given text will NOT be trimmed - it's valid to look for something like "hello   " with
+     * three trailing spaces. A value of null will be treated the same as an empty string (no-op).
+     * </p>
+     */
+    public TextFilter(String contains, boolean isCaseSensitive) {
+        this.contains = contains == null ? "" : contains;
+        this.isCaseSensitive = isCaseSensitive;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by text content";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || note.getText() == null || note.getText().isBlank()) {
+            // Don't bother filtering if there's nothing to filter.
+            return false;
+        }
+        String candidateText = note.getText();
+        String toFind = contains;
+        if (!isCaseSensitive) {
+            candidateText = candidateText.toLowerCase(Locale.ROOT);
+            toFind = toFind.toLowerCase();
+        }
+        return !candidateText.contains(toFind);
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/UndatedFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/UndatedFilter.java
@@ -1,0 +1,21 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+/**
+ * A Filter that specifically looks for undated Notes.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class UndatedFilter extends Filter {
+    @Override
+    public String getDescription() {
+        return "Undated notes only";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        // Filter out null notes, and anything that has a date.
+        return note == null || note.hasDate() || note.getDate() != null;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/YearFilter.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/snotes/model/filter/YearFilter.java
@@ -1,0 +1,61 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+
+/**
+ * This Filter can be used to filter Notes by the year of their calendar date.
+ * For more specific date filtering, use the DateFilter instead, or consider
+ * combining this filter with a MonthFilter ("all notes from December of 2020").
+ * If you find yourself combining a YearFilter with a MonthFilter and a DayOfMonthFilter,
+ * then you should probably just use a single DateFilter instead.
+ * <p>
+ * <B>NOTE:</B> all date filters automatically filter out undated notes.
+ * Applying any type of date filter will automatically exclude all notes that do not have a date,
+ * or whose date is null.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class YearFilter extends Filter {
+
+    public enum FilterType {
+        BEFORE_EXCLUSIVE, BEFORE_INCLUSIVE, ON, AFTER_INCLUSIVE, AFTER_EXCLUSIVE
+    }
+
+    private final int targetYear;
+    private final FilterType filterType;
+
+    /**
+     * Creates a YearFilter for the given target year and filter type.
+     * We don't validate targetYear - any integer is technically a valid year, even negative integers.
+     * Just don't be surprised if Integer.MAX_VALUE doesn't yield many matches.
+     */
+    public YearFilter(int targetYear, FilterType filterType) {
+        if (filterType == null) {
+            throw new IllegalArgumentException("filterType cannot be null");
+        }
+        this.targetYear = targetYear;
+        this.filterType = filterType;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filter by year";
+    }
+
+    @Override
+    public boolean isFiltered(Note note) {
+        if (note == null || !note.hasDate() || note.getDate() == null) {
+            // All date filters automatically filter out non-dated notes.
+            return true;
+        }
+        int noteYear = note.getDate().getYear();
+        return switch (filterType) {
+            case BEFORE_EXCLUSIVE -> noteYear >= targetYear;
+            case BEFORE_INCLUSIVE -> noteYear > targetYear;
+            case ON -> noteYear != targetYear;
+            case AFTER_INCLUSIVE -> noteYear < targetYear;
+            case AFTER_EXCLUSIVE -> noteYear <= targetYear;
+        };
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/QueryTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/QueryTest.java
@@ -1,0 +1,200 @@
+package ca.corbett.crypttext.extensions.snotes.model;
+
+import ca.corbett.crypttext.extensions.snotes.model.filter.DateFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.DayOfMonthFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.DayOfWeekFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.FilterTest;
+import ca.corbett.crypttext.extensions.snotes.model.filter.MonthFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.TextFilter;
+import ca.corbett.crypttext.extensions.snotes.model.filter.YearFilter;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QueryTest extends FilterTest {
+
+    @Test
+    public void filter_withEmptyQuery_shouldFilterNothing() {
+        // GIVEN an empty Query:
+        Query query = new Query();
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN nothing should have been filtered:
+        assertNotNull(results);
+        assertEquals(unfilteredList.size(), results.size());
+    }
+
+    @Test
+    public void filter_singleDateFilterMatches_shouldSucceed() {
+        // GIVEN a query with a single DateFilter that is matched in our test set:
+        Query query = new Query();
+        query.addFilter(new DateFilter(SPECIAL_DATE, DateFilter.FilterType.ON));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN we should get back our two test notes that have this date:
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        assertEquals(SPECIAL_DATE, results.get(0).getDate());
+        assertEquals(SPECIAL_DATE, results.get(1).getDate());
+    }
+
+    @Test
+    public void filter_YearAndMonthFilterMatches_shouldSucceed() {
+        // GIVEN a query with a YearFilter and a MonthFilter that are matched in our test set:
+        Query query = new Query();
+        query.addFilter(new YearFilter(1997, YearFilter.FilterType.ON));
+        query.addFilter(new MonthFilter(4, MonthFilter.FilterType.IS));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN we should get back our two test Notes that have this date:
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        assertEquals(SPECIAL_DATE, results.get(0).getDate());
+        assertEquals(SPECIAL_DATE, results.get(1).getDate());
+    }
+
+    @Test
+    public void filter_YearAndMonthFilterMatchesTextFilterNoMatch_shouldReturnNothing() {
+        // GIVEN a query with a YearFilter and a MonthFilter that are matched in our test set:
+        Query query = new Query();
+        query.addFilter(new YearFilter(1997, YearFilter.FilterType.ON));
+        query.addFilter(new MonthFilter(4, MonthFilter.FilterType.IS));
+
+        // AND GIVEN a text filter that does NOT match any of our test notes:
+        query.addFilter(new TextFilter("blah de blah blah"));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN we should find that all results are filtered, because no Note matches all of our filters:
+        assertNotNull(results);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void filter_betweenInclusiveWithMatches_shouldSucceed() {
+        // GIVEN a query with two DateFilters that describe a BETWEEN condition:
+        Query query = new Query();
+        query.addFilter(new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_INCLUSIVE));
+        query.addFilter(new DateFilter(FEB_15_2020, DateFilter.FilterType.BEFORE_INCLUSIVE));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN we should find the two test Notes that have dates between (and including) our two boundary dates:
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        YMDDate actualDate1 = results.get(0).getDate();
+        YMDDate actualDate2 = results.get(1).getDate();
+        assertNotNull(actualDate1);
+        assertNotNull(actualDate2);
+
+        // We can't guarantee the order in which Notes are returned from a search,
+        // but we should be able to confirm that our two expected dates are present in the results:
+        assertTrue(JAN_1_2020.equals(actualDate1) || JAN_1_2020.equals(actualDate2));
+        assertTrue(FEB_15_2020.equals(actualDate1) || FEB_15_2020.equals(actualDate2));
+    }
+
+    @Test
+    public void filter_betweenExclusiveWithoutMatches_shouldSucceed() {
+        // GIVEN a query with two DateFilters that describe a BETWEEN condition:
+        Query query = new Query();
+        query.addFilter(new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_EXCLUSIVE));
+        query.addFilter(new DateFilter(FEB_15_2020, DateFilter.FilterType.BEFORE_EXCLUSIVE));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN our two test notes that are right on the boundary of the range should be filtered out:
+        assertNotNull(results);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void filter_withMultipleMatchingFilters_shouldSucceed() {
+        // GIVEN a ridiculous setup with four filters that specify an exact date:
+        //   (obviously it would be easier to use a single DateFilter, but let's just try it)
+        Query query = new Query();
+        query.addFilter(new YearFilter(1997, YearFilter.FilterType.ON));
+        query.addFilter(new MonthFilter(4, MonthFilter.FilterType.IS));
+        query.addFilter(new DayOfMonthFilter(21, DayOfMonthFilter.FilterType.IS));
+        query.addFilter(new DayOfWeekFilter(DayOfWeek.MONDAY, DayOfWeekFilter.FilterType.IS));
+
+        // WHEN we try to filter our test list:
+        List<Note> results = query.filter(unfilteredList);
+
+        // THEN we should get back the two test Notes that have that exact date:
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        assertEquals(SPECIAL_DATE, results.get(0).getDate());
+        assertEquals(SPECIAL_DATE, results.get(1).getDate());
+    }
+
+    @Test
+    public void constructor_withNoName_shouldCreateUnnamedQuery() {
+        // WHEN we construct a Query with no name:
+        Query query = new Query();
+
+        // THEN the Query should have the default name:
+        assertNotNull(query.getName());
+        assertEquals(Query.DEFAULT_NAME, query.getName());
+    }
+
+    @Test
+    public void setName_withNullOrBlank_shouldSetDefaultName() {
+        // GIVEN a Query with a non-default name:
+        Query query = new Query();
+        query.setName("My Custom Query");
+        assertEquals("My Custom Query", query.getName());
+
+        // WHEN we set the name to null:
+        query.setName((String)null);
+
+        // THEN the name should be reset to the default:
+        assertEquals(Query.DEFAULT_NAME, query.getName());
+
+        // WHEN we set the name to blank:
+        query.setName("   ");
+
+        // THEN the name should again be reset to the default:
+        assertEquals(Query.DEFAULT_NAME, query.getName());
+    }
+
+    @Test
+    public void setName_withNameTooLong_shouldTruncateName() {
+        // GIVEN a Query:
+        Query query = new Query();
+
+        // WHEN we set the name to a string that is longer than the limit:
+        String longName = "This is a very long query name that exceeds the limit";
+        query.setName(longName);
+
+        // THEN the name should be truncated to the limit:
+        assertEquals(Query.NAME_LENGTH_LIMIT, query.getName().length());
+        assertEquals(longName.substring(0, Query.NAME_LENGTH_LIMIT), query.getName());
+    }
+
+    @Test
+    public void setName_withValidName_shouldSet() {
+        // GIVEN a Query:
+        Query query = new Query();
+
+        // WHEN we set the name to a valid string that is within the limit:
+        String validName = "My Valid Query Name";
+        query.setName(validName);
+
+        // THEN the name should be set correctly:
+        assertEquals(validName, query.getName());
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilterTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DateFilterTest extends FilterTest {
 
     @Test
-    public void constructor_willNullInput_shouldThrow() {
+    public void constructor_withNullInput_shouldThrow() {
         // WHEN we give garbage to the constructor, THEN it should immediately throw:
         assertThrows(IllegalArgumentException.class, () -> new DateFilter(null, DateFilter.FilterType.ON));
         assertThrows(IllegalArgumentException.class, () -> new DateFilter(SPECIAL_DATE, null));

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DateFilterTest.java
@@ -1,0 +1,144 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DateFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_willNullInput_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new DateFilter(null, DateFilter.FilterType.ON));
+        assertThrows(IllegalArgumentException.class, () -> new DateFilter(SPECIAL_DATE, null));
+    }
+
+    @Test
+    public void isFiltered_withUndatedNote_shouldFilter() {
+        // WHEN we use an undated Note, THEN it should automatically be filtered:
+        assertTrue(new DateFilter(SPECIAL_DATE, DateFilter.FilterType.ON).isFiltered(NOTE_UNDATED_UNTAGGED));
+    }
+
+    @Test
+    public void isFiltered_ONwithDifferentDate_shouldFilter() {
+        // GIVEN a DateFilter with ON type and a target date different from our test note:
+        DateFilter filter = new DateFilter(SPECIAL_DATE, DateFilter.FilterType.ON);
+
+        // WHEN we try to filter a note with a different date:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because the Note's date does not match the target date:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_ONwithExactMatch_shouldNotFilter() {
+        // GIVEN a DateFilter with ON type and the exact date of our test note:
+        DateFilter filter = new DateFilter(SPECIAL_DATE, DateFilter.FilterType.ON);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should not be filtered, because the Note's date matches the target date:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_EXCLUSIVEwithDateBeforeTarget_shouldNotFilter() {
+        // GIVEN a DateFilter with BEFORE_EXCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.BEFORE_EXCLUSIVE);
+
+        // WHEN we try to filter a note that is before the target date:
+        boolean actual = filter.isFiltered(NOTE_VERY_OLD);
+
+        // THEN it should not be filtered, because strictly earlier dates are included:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_EXCLUSIVEwithDateOnTarget_shouldFilter() {
+        // GIVEN a DateFilter with BEFORE_EXCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.BEFORE_EXCLUSIVE);
+
+        // WHEN we try to filter a note that is exactly on the target date:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because BEFORE_EXCLUSIVE rejects boundary matches:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_INCLUSIVEwithDateOnTarget_shouldNotFilter() {
+        // GIVEN a DateFilter with BEFORE_INCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.BEFORE_INCLUSIVE);
+
+        // WHEN we try to filter a note that is exactly on the target date:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because BEFORE_INCLUSIVE includes boundary matches:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_INCLUSIVEwithDateAfterTarget_shouldFilter() {
+        // GIVEN a DateFilter with BEFORE_INCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.BEFORE_INCLUSIVE);
+
+        // WHEN we try to filter a note that is after the target date:
+        boolean actual = filter.isFiltered(NOTE_FEB_15_2020);
+
+        // THEN it should be filtered, because later dates are excluded:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_INCLUSIVEwithDateOnTarget_shouldNotFilter() {
+        // GIVEN a DateFilter with AFTER_INCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_INCLUSIVE);
+
+        // WHEN we try to filter a note that is exactly on the target date:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because AFTER_INCLUSIVE includes boundary matches:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_INCLUSIVEwithDateBeforeTarget_shouldFilter() {
+        // GIVEN a DateFilter with AFTER_INCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_INCLUSIVE);
+
+        // WHEN we try to filter a note that is before the target date:
+        boolean actual = filter.isFiltered(NOTE_VERY_OLD);
+
+        // THEN it should be filtered, because earlier dates are excluded:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_EXCLUSIVEwithDateAfterTarget_shouldNotFilter() {
+        // GIVEN a DateFilter with AFTER_EXCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_EXCLUSIVE);
+
+        // WHEN we try to filter a note that is after the target date:
+        boolean actual = filter.isFiltered(NOTE_FEB_15_2020);
+
+        // THEN it should not be filtered, because strictly later dates are included:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_EXCLUSIVEwithDateOnTarget_shouldFilter() {
+        // GIVEN a DateFilter with AFTER_EXCLUSIVE type:
+        DateFilter filter = new DateFilter(JAN_1_2020, DateFilter.FilterType.AFTER_EXCLUSIVE);
+
+        // WHEN we try to filter a note that is exactly on the target date:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because AFTER_EXCLUSIVE rejects boundary matches:
+        assertTrue(actual);
+    }
+
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfMonthFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfMonthFilterTest.java
@@ -1,0 +1,75 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DayOfMonthFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_withNullInput_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new DayOfMonthFilter(33, DayOfMonthFilter.FilterType.IS));
+        assertThrows(IllegalArgumentException.class, () -> new DayOfMonthFilter(1, null));
+        assertThrows(IllegalArgumentException.class, () -> new DayOfMonthFilter(-1, DayOfMonthFilter.FilterType.IS));
+        assertThrows(IllegalArgumentException.class, () -> new DayOfMonthFilter(0, DayOfMonthFilter.FilterType.IS));
+    }
+
+    @Test
+    public void isFiltered_withUndatedNote_shouldFilter() {
+        // WHEN we use an undated Note, THEN it should automatically be filtered:
+        assertTrue(new DayOfMonthFilter(1, DayOfMonthFilter.FilterType.IS).isFiltered(NOTE_UNDATED_UNTAGGED));
+    }
+
+    @Test
+    public void isFiltered_ISwithMatchingDayOfMonth_shouldNotFilter() {
+        // GIVEN a DayOfMonthFilter with IS type and a target day of month that matches our test note:
+        DayOfMonthFilter filter = new DayOfMonthFilter(1, DayOfMonthFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because the Note's day of month matches the target day of month:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_ISwithNonMatchingDayOfMonth_shouldFilter() {
+        // GIVEN a DayOfMonthFilter with IS type and a target day of month that does not match our test note:
+        DayOfMonthFilter filter = new DayOfMonthFilter(2, DayOfMonthFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because the Note's day of month does not match the target day of month:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithMatchingDayOfMonth_shouldFilter() {
+        // GIVEN a DayOfMonthFilter with IS_NOT type and a target day of month that
+        // matches our test note:
+        DayOfMonthFilter filter = new DayOfMonthFilter(1, DayOfMonthFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because it matches, and we're in IS_NOT mode:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithNonMatchingDayOfMonth_shouldNotFilter() {
+        // GIVEN a DayOfMonthFilter with IS_NOT type and a target day of month that
+        // does not match our test note:
+        DayOfMonthFilter filter = new DayOfMonthFilter(2, DayOfMonthFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because it does not match, and we're in IS_NOT mode:
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfWeekFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/DayOfWeekFilterTest.java
@@ -1,0 +1,76 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DayOfWeekFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_withNullInput_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new DayOfWeekFilter(null, DayOfWeekFilter.FilterType.IS));
+        assertThrows(IllegalArgumentException.class, () -> new DayOfWeekFilter(DayOfWeek.MONDAY, null));
+    }
+
+    @Test
+    public void isFiltered_undatedNote_shouldFilter() {
+        // WHEN we use an undated Note, THEN it should automatically be filtered:
+        assertTrue(
+                new DayOfWeekFilter(DayOfWeek.MONDAY, DayOfWeekFilter.FilterType.IS).isFiltered(NOTE_UNDATED_UNTAGGED));
+    }
+
+    @Test
+    public void isFiltered_ISwithMatchingDayOfWeek_shouldNotFilter() {
+        // GIVEN a DayOfWeekFilter with IS type and a target day of week that matches our test note:
+        DayOfWeekFilter filter = new DayOfWeekFilter(DayOfWeek.MONDAY, DayOfWeekFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should not be filtered, because the Note's day of week matches the target day of week:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_ISwithNonMatchingDayOfWeek_shouldFilter() {
+        // GIVEN a DayOfWeekFilter with IS type and a target day of week that does not match our test note:
+        DayOfWeekFilter filter = new DayOfWeekFilter(DayOfWeek.TUESDAY, DayOfWeekFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should be filtered, because the Note's day of week does not match the target day of week:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithMatchingDayOfWeek_shouldFilter() {
+        // GIVEN a DayOfWeekFilter with IS_NOT type and a target day of week that
+        // matches our test note:
+        DayOfWeekFilter filter = new DayOfWeekFilter(DayOfWeek.MONDAY, DayOfWeekFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should be filtered, because it matches, and we're in IS_NOT mode:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithNonMatchingDayOfWeek_shouldNotFilter() {
+        // GIVEN a DayOfWeekFilter with IS_NOT type and a target day of week that
+        // does not match our test note:
+        DayOfWeekFilter filter = new DayOfWeekFilter(DayOfWeek.TUESDAY, DayOfWeekFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should not be filtered, because it does not match, and we're in IS_NOT mode:
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/FilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/FilterTest.java
@@ -27,7 +27,7 @@ public abstract class FilterTest {
     protected static final Note NOTE_WITH_TEXT_TO_FIND = new Note().setText("A note containing the unique text: "
                                                                                     + TEXT_TO_FIND
                                                                                     + " blah blah");
-    protected static final Note NOTE_UNDATED_UNTAGGED = new Note().setText("Un undated and untagged note.");
+    protected static final Note NOTE_UNDATED_UNTAGGED = new Note().setText("An undated and untagged note.");
     protected static final Note NOTE_NO_TEXT = new Note().tag(NON_DATE_TAG1);
     protected static final Note NOTE_DATED_UNTAGGED = new Note().setText("A note with a date tag but no non-date tags.")
                                                                 .setDate(SPECIAL_DATE);

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/FilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/FilterTest.java
@@ -1,0 +1,65 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import ca.corbett.crypttext.extensions.snotes.model.Tag;
+import ca.corbett.crypttext.extensions.snotes.model.YMDDate;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The abstract base test class for all Filter tests.
+ */
+public abstract class FilterTest {
+
+    // ---- Test contents ----
+    protected static final String TEXT_TO_FIND = "SomeUniqueStringThatWillOnlyAppearInOneNote";
+    protected static final YMDDate SPECIAL_DATE = new YMDDate("1997-04-21");
+    protected static final YMDDate JAN_1_2020 = new YMDDate("2020-01-01");
+    protected static final YMDDate FEB_15_2020 = new YMDDate("2020-02-15");
+    protected static final YMDDate VERY_OLD_DATE = new YMDDate("1900-01-01");
+    protected static final YMDDate VERY_FUTURE_DATE = new YMDDate("2100-01-01");
+    protected static final Tag NON_DATE_TAG1 = new Tag("work1");
+    protected static final Tag NON_DATE_TAG2 = new Tag("work2");
+
+    // ---- Test Note instances ----
+    protected static final Note NOTE_WITH_TEXT_TO_FIND = new Note().setText("A note containing the unique text: "
+                                                                                    + TEXT_TO_FIND
+                                                                                    + " blah blah");
+    protected static final Note NOTE_UNDATED_UNTAGGED = new Note().setText("Un undated and untagged note.");
+    protected static final Note NOTE_NO_TEXT = new Note().tag(NON_DATE_TAG1);
+    protected static final Note NOTE_DATED_UNTAGGED = new Note().setText("A note with a date tag but no non-date tags.")
+                                                                .setDate(SPECIAL_DATE);
+    protected static final Note NOTE_DATED_TAGGED = new Note().setText("A note with a date tag and a non-date tag.")
+                                                              .setDate(SPECIAL_DATE)
+                                                              .tag(NON_DATE_TAG1);
+    protected static final Note NOTE_VERY_OLD = new Note().setText("A note with a date that is very old.")
+                                                          .setDate(VERY_OLD_DATE);
+    protected static final Note NOTE_VERY_FUTURE = new Note().setText("A note with a date that is very future.")
+                                                             .setDate(VERY_FUTURE_DATE);
+    protected static final Note NOTE_JAN_1_2020 = new Note().setText("Random note from Jan 2020").setDate(JAN_1_2020);
+    protected static final Note NOTE_FEB_15_2020 = new Note().setText("Random note from Feb 2020").setDate(FEB_15_2020);
+    protected static final Note NOTE_MULTIPLE_TAGS = new Note().setText("With multiple tags").tag(NON_DATE_TAG1)
+                                                               .tag(NON_DATE_TAG2);
+    protected static final List<Note> unfilteredList = new ArrayList<>();
+
+    @BeforeAll
+    public static void setup() {
+        // Create an unfiltered list of test Notes that our
+        // subclass tests can use. Modify this list with caution!
+        // It will require updating test expectations in some or all subclasses.
+        // The order doesn't matter, but adding or removing Notes will likely cause some tests to fail.
+        unfilteredList.clear();
+        unfilteredList.add(NOTE_UNDATED_UNTAGGED);
+        unfilteredList.add(NOTE_DATED_UNTAGGED);
+        unfilteredList.add(NOTE_DATED_TAGGED);
+        unfilteredList.add(NOTE_NO_TEXT);
+        unfilteredList.add(NOTE_VERY_OLD);
+        unfilteredList.add(NOTE_VERY_FUTURE);
+        unfilteredList.add(NOTE_JAN_1_2020);
+        unfilteredList.add(NOTE_WITH_TEXT_TO_FIND);
+        unfilteredList.add(NOTE_FEB_15_2020);
+        unfilteredList.add(NOTE_MULTIPLE_TAGS);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/MonthFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/MonthFilterTest.java
@@ -1,0 +1,74 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MonthFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_withNullInput_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new MonthFilter(13, MonthFilter.FilterType.IS));
+        assertThrows(IllegalArgumentException.class, () -> new MonthFilter(0, MonthFilter.FilterType.IS));
+        assertThrows(IllegalArgumentException.class, () -> new MonthFilter(1, null));
+    }
+
+    @Test
+    public void isFiltered_withUndatedNote_shouldFilter() {
+        // WHEN we use an undated Note, THEN it should automatically be filtered:
+        assertTrue(new MonthFilter(1, MonthFilter.FilterType.IS).isFiltered(NOTE_UNDATED_UNTAGGED));
+    }
+
+    @Test
+    public void isFiltered_ISwithMatchingMonth_shouldNotFilter() {
+        // GIVEN a MonthFilter with IS type and a target month that matches our test note:
+        MonthFilter filter = new MonthFilter(1, MonthFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because the Note's month matches the target month:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_ISwithNonMatchingMonth_shouldFilter() {
+        // GIVEN a MonthFilter with IS type and a target month that does not match our test note:
+        MonthFilter filter = new MonthFilter(2, MonthFilter.FilterType.IS);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because the Note's month does not match the target month:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithMatchingMonth_shouldFilter() {
+        // GIVEN a MonthFilter with IS_NOT type and a target month that
+        // matches our test note:
+        MonthFilter filter = new MonthFilter(1, MonthFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because it matches, and we're in IS_NOT mode:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_IS_NOTwithNonMatchingMonth_shouldNotFilter() {
+        // GIVEN a MonthFilter with IS_NOT type and a target month that
+        // does not match our test note:
+        MonthFilter filter = new MonthFilter(2, MonthFilter.FilterType.IS_NOT);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because it does not match, and we're in IS_NOT mode:
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/TagFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/TagFilterTest.java
@@ -1,0 +1,128 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TagFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_withNullOrEmptyParameters_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new TagFilter(null, TagFilter.FilterType.ALL));
+        assertThrows(IllegalArgumentException.class, () -> new TagFilter(List.of(), TagFilter.FilterType.ALL));
+        assertThrows(IllegalArgumentException.class, () -> new TagFilter(List.of(NON_DATE_TAG1), null));
+    }
+
+    @Test
+    public void isFiltered_ALLwithNoTags_shouldFilter() {
+        // GIVEN a TagFilter with ALL type and no tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ALL);
+
+        // WHEN we try to filter a Note with no tags:
+        boolean actual = filter.isFiltered(NOTE_UNDATED_UNTAGGED);
+
+        // THEN it should be filtered, because the Note does not have all of the required tags:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_ALLwithSomeTags_shouldFilter() {
+        // GIVEN a TagFilter with ALL type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ALL);
+
+        // WHEN we try to filter a Note with only one of the required tags:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should be filtered, because the Note does not have all of the required tags:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_ALLwithAllTags_shouldNotFilter() {
+        // GIVEN a TagFilter with ALL type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ALL);
+
+        // WHEN we try to filter a Note with all of the required tags:
+        boolean actual = filter.isFiltered(NOTE_MULTIPLE_TAGS);
+
+        // THEN it should not be filtered, because the Note has all of the required tags:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_ANYwithNoTags_shouldFilter() {
+        // GIVEN a TagFilter with ANY type and no tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ANY);
+
+        // WHEN we try to filter a Note with no tags:
+        boolean actual = filter.isFiltered(NOTE_UNDATED_UNTAGGED);
+
+        // THEN it should be filtered, because the Note does not have any of the required tags:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_ANYwithSomeTags_shouldNotFilter() {
+        // GIVEN a TagFilter with ANY type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ANY);
+
+        // WHEN we try to filter a Note with only one of the required tags:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should not be filtered, because the Note has at least one of the required tags:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_ANYwithAllTags_shouldNotFilter() {
+        // GIVEN a TagFilter with ANY type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.ANY);
+
+        // WHEN we try to filter a Note with all of the required tags:
+        boolean actual = filter.isFiltered(NOTE_MULTIPLE_TAGS);
+
+        // THEN it should not be filtered, because the Note has at least one of the required tags:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_NONEwithNoTags_shouldNotFilter() {
+        // GIVEN a TagFilter with NONE type and no tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.NONE);
+
+        // WHEN we try to filter a Note with no tags:
+        boolean actual = filter.isFiltered(NOTE_UNDATED_UNTAGGED);
+
+        // THEN it should not be filtered, because the Note does not have any of the forbidden tags:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_NONEwithSomeTags_shouldFilter() {
+        // GIVEN a TagFilter with NONE type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.NONE);
+
+        // WHEN we try to filter a Note with only one of the forbidden tags:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should be filtered, because the Note has at least one of the forbidden tags:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_NONEwithAllTags_shouldFilter() {
+        // GIVEN a TagFilter with NONE type and some tags:
+        TagFilter filter = new TagFilter(List.of(NON_DATE_TAG1, NON_DATE_TAG2), TagFilter.FilterType.NONE);
+
+        // WHEN we try to filter a Note with all of the forbidden tags:
+        boolean actual = filter.isFiltered(NOTE_MULTIPLE_TAGS);
+
+        // THEN it should be filtered, because the Note has at least one of the forbidden tags:
+        assertTrue(actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/TextFilterTest.java
@@ -1,0 +1,84 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TextFilterTest extends FilterTest {
+
+    @Test
+    public void isFiltered_caseInsensitive_shouldMatchAnyCase() {
+        // GIVEN our target text in various cases:
+        String targetTextUpper = TEXT_TO_FIND.toUpperCase(Locale.ROOT);
+        String targetTextLower = TEXT_TO_FIND.toLowerCase(Locale.ROOT);
+        String targetTextExact = TEXT_TO_FIND;
+
+        // WHEN we try to filter it:
+        boolean actualUpper = new TextFilter(targetTextUpper).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+        boolean actualLower = new TextFilter(targetTextLower).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+        boolean actualExact = new TextFilter(targetTextExact).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+
+        // THEN none of them should be filtered, because we are doing case-insensitive matching by default:
+        assertFalse(actualUpper);
+        assertFalse(actualLower);
+        assertFalse(actualExact);
+    }
+
+    @Test
+    public void isFiltered_caseSensitive_shouldOnlyMatchExact() {
+        // GIVEN our target text in various cases:
+        String targetTextUpper = TEXT_TO_FIND.toUpperCase(Locale.ROOT);
+        String targetTextLower = TEXT_TO_FIND.toLowerCase(Locale.ROOT);
+        String targetTextExact = TEXT_TO_FIND;
+
+        // WHEN we try to filter it:
+        boolean actualUpper = new TextFilter(targetTextUpper, true).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+        boolean actualLower = new TextFilter(targetTextLower, true).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+        boolean actualExact = new TextFilter(targetTextExact, true).isFiltered(NOTE_WITH_TEXT_TO_FIND);
+
+        // THEN only the exact match should survive, both others should get filtered:
+        assertTrue(actualUpper);
+        assertTrue(actualLower);
+        assertFalse(actualExact);
+    }
+
+    @Test
+    public void isFiltered_withTextNotPresent_shouldFilter() {
+        // GIVEN a TextFilter with text that is not present in the Note:
+        TextFilter filter = new TextFilter("This text does not appear in the note.");
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_WITH_TEXT_TO_FIND);
+
+        // THEN it should be filtered:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_withNoteWithNoText_shouldNotFilter() {
+        // GIVEN a Note that has no text at all:
+        Note noteWithNoText = NOTE_NO_TEXT;
+
+        // WHEN we try to filter it with any TextFilter:
+        TextFilter filter = new TextFilter(TEXT_TO_FIND);
+
+        // THEN it should not be filtered, because there's nothing to filter:
+        assertFalse(filter.isFiltered(noteWithNoText));
+    }
+
+    @Test
+    public void isFiltered_withNullNote_shouldNotFilter() {
+        // GIVEN a null Note:
+        Note nullNote = null;
+
+        // WHEN we try to filter it with any TextFilter:
+        TextFilter filter = new TextFilter(TEXT_TO_FIND);
+
+        // THEN it should not be filtered, because there's nothing to filter:
+        assertFalse(filter.isFiltered(nullNote));
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/UndatedFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/UndatedFilterTest.java
@@ -1,0 +1,46 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import ca.corbett.crypttext.extensions.snotes.model.Note;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UndatedFilterTest extends FilterTest {
+
+    @Test
+    public void isFiltered_withNullNote_shouldFilter() {
+        // GIVEN a null Note:
+        Note note = null;
+
+        // WHEN we try to filter it:
+        boolean actual = new UndatedFilter().isFiltered(note);
+
+        // THEN it should be filtered:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_withDatedNote_shouldFilter() {
+        // GIVEN a Note with a date:
+        Note note = NOTE_DATED_TAGGED;
+
+        // WHEN we try to filter it:
+        boolean actual = new UndatedFilter().isFiltered(note);
+
+        // THEN it should be filtered:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_withNoDate_shouldNotFilter() {
+        // GIVEN a Note with no date:
+        Note note = NOTE_UNDATED_UNTAGGED;
+
+        // WHEN we try to filter it:
+        boolean actual = new UndatedFilter().isFiltered(note);
+
+        // THEN it should not be filtered:
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/YearFilterTest.java
+++ b/src/test/java/ca/corbett/crypttext/extensions/snotes/model/filter/YearFilterTest.java
@@ -1,0 +1,142 @@
+package ca.corbett.crypttext.extensions.snotes.model.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YearFilterTest extends FilterTest {
+
+    @Test
+    public void constructor_withNullInput_shouldThrow() {
+        // WHEN we give garbage to the constructor, THEN it should immediately throw:
+        assertThrows(IllegalArgumentException.class, () -> new YearFilter(2020, null));
+    }
+
+    @Test
+    public void isFiltered_withUndatedNote_shouldFilter() {
+        // WHEN we use an undated Note, THEN it should automatically be filtered:
+        assertTrue(new YearFilter(2020, YearFilter.FilterType.ON).isFiltered(NOTE_UNDATED_UNTAGGED));
+    }
+
+    @Test
+    public void isFiltered_ONwithDifferentYear_shouldFilter() {
+        // GIVEN a YearFilter with ON type and a target year different from our test note:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.ON);
+
+        // WHEN we try to filter a note from a different year:
+        boolean actual = filter.isFiltered(NOTE_DATED_TAGGED);
+
+        // THEN it should be filtered, because the Note's year does not match the target year:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_ONwithExactYearMatch_shouldNotFilter() {
+        // GIVEN a YearFilter with ON type and the exact year of our test note:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.ON);
+
+        // WHEN we try to filter the note:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because the Note's year matches the target year:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_EXCLUSIVEwithYearBeforeTarget_shouldNotFilter() {
+        // GIVEN a YearFilter with BEFORE_EXCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.BEFORE_EXCLUSIVE);
+
+        // WHEN we try to filter a note whose year is before the target year:
+        boolean actual = filter.isFiltered(NOTE_VERY_OLD);
+
+        // THEN it should not be filtered, because strictly earlier years are included:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_EXCLUSIVEwithYearOnTarget_shouldFilter() {
+        // GIVEN a YearFilter with BEFORE_EXCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.BEFORE_EXCLUSIVE);
+
+        // WHEN we try to filter a note whose year is exactly the target year:
+        boolean actual = filter.isFiltered(NOTE_FEB_15_2020);
+
+        // THEN it should be filtered, because BEFORE_EXCLUSIVE rejects boundary matches:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_INCLUSIVEwithYearOnTarget_shouldNotFilter() {
+        // GIVEN a YearFilter with BEFORE_INCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.BEFORE_INCLUSIVE);
+
+        // WHEN we try to filter a note whose year is exactly the target year:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should not be filtered, because BEFORE_INCLUSIVE includes boundary matches:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_BEFORE_INCLUSIVEwithYearAfterTarget_shouldFilter() {
+        // GIVEN a YearFilter with BEFORE_INCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.BEFORE_INCLUSIVE);
+
+        // WHEN we try to filter a note whose year is after the target year:
+        boolean actual = filter.isFiltered(NOTE_VERY_FUTURE);
+
+        // THEN it should be filtered, because later years are excluded:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_INCLUSIVEwithYearOnTarget_shouldNotFilter() {
+        // GIVEN a YearFilter with AFTER_INCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.AFTER_INCLUSIVE);
+
+        // WHEN we try to filter a note whose year is exactly the target year:
+        boolean actual = filter.isFiltered(NOTE_FEB_15_2020);
+
+        // THEN it should not be filtered, because AFTER_INCLUSIVE includes boundary matches:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_INCLUSIVEwithYearBeforeTarget_shouldFilter() {
+        // GIVEN a YearFilter with AFTER_INCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.AFTER_INCLUSIVE);
+
+        // WHEN we try to filter a note whose year is before the target year:
+        boolean actual = filter.isFiltered(NOTE_VERY_OLD);
+
+        // THEN it should be filtered, because earlier years are excluded:
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_EXCLUSIVEwithYearAfterTarget_shouldNotFilter() {
+        // GIVEN a YearFilter with AFTER_EXCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.AFTER_EXCLUSIVE);
+
+        // WHEN we try to filter a note whose year is after the target year:
+        boolean actual = filter.isFiltered(NOTE_VERY_FUTURE);
+
+        // THEN it should not be filtered, because strictly later years are included:
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isFiltered_AFTER_EXCLUSIVEwithYearOnTarget_shouldFilter() {
+        // GIVEN a YearFilter with AFTER_EXCLUSIVE type:
+        YearFilter filter = new YearFilter(2020, YearFilter.FilterType.AFTER_EXCLUSIVE);
+
+        // WHEN we try to filter a note whose year is exactly the target year:
+        boolean actual = filter.isFiltered(NOTE_JAN_1_2020);
+
+        // THEN it should be filtered, because AFTER_EXCLUSIVE rejects boundary matches:
+        assertTrue(actual);
+    }
+}


### PR DESCRIPTION
This PR addresses issue #7 by introducing the `Query` model object and associated filter classes. These classes will be used for searching through collections of Note objects, filtering them by date, by tag, or by text contents. Filters can be combined together - currently, this is AND only, but future versions may support OR and XOR. Added unit tests for all new classes.

Out of scope: UI for building Query instances (future ticket)

Out of scope: Query persistence for saving queries for re-use later (future ticket)

Closes #7 